### PR TITLE
Fix clippy errors and run clippy on Travis-CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ matrix:
   allow_failures:
     - rust: nightly
 before_script:
+  - rustup component add clippy
   - rustup component add rustfmt
 script:
   - cargo fmt --all -- --check
   - cargo build
   - cargo test
+  - cargo clippy

--- a/finalfrontier-utils/src/bin/ff-train.rs
+++ b/finalfrontier-utils/src/bin/ff-train.rs
@@ -286,7 +286,7 @@ where
 {
     let n_tokens = sgd.model().input_vocab().n_types();
 
-    let pb = ProgressBar::new(config.epochs as u64 * n_tokens as u64);
+    let pb = ProgressBar::new(u64::from(config.epochs) * n_tokens as u64);
     pb.set_style(
         ProgressStyle::default_bar().template("{bar:40} {percent}% {msg} ETA: {eta_precise}"),
     );
@@ -356,7 +356,7 @@ where
 
     let sentences = SentenceIterator::new(BufReader::new(file_progress));
 
-    let mut builder: VocabBuilder<String> = VocabBuilder::new(config.clone());
+    let mut builder: VocabBuilder<String> = VocabBuilder::new(*config);
     for sentence in sentences {
         let sentence = sentence.or_exit("Cannot read sentence", 1);
 

--- a/finalfrontier/src/deps.rs
+++ b/finalfrontier/src/deps.rs
@@ -104,6 +104,7 @@ impl<'a> DependencyIterator<'a> {
     /// Constructs a new `DependencyIterator` which returns up to `max_depth`-order dependencies.
     ///
     /// If `max_depth == 0`, all contexts are extracted.
+    #[allow(dead_code)]
     pub fn new(graph: &'a DepGraph<'a>, max_depth: usize) -> Self {
         DependencyIterator {
             max_depth,

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -40,7 +40,6 @@ mod config;
 pub use config::{Config, LossType, ModelType};
 
 mod deps;
-pub(crate) use deps::{DepIter, Dependency, DependencyIterator, PathIter};
 
 mod io;
 pub use io::{SentenceIterator, WriteModelBinary, WriteModelText, WriteModelWord2Vec};

--- a/finalfrontier/src/sampling.rs
+++ b/finalfrontier/src/sampling.rs
@@ -84,6 +84,7 @@ where
 /// descending frequency. Since the token frequencies (presumably) have a
 /// Zipfian distribution, this will pick a token with a probability that
 /// is proportional to its frequency.
+#[allow(dead_code)]
 pub struct ZipfRangeGenerator<R> {
     upper_bound: usize,
     exponent: f64,
@@ -163,6 +164,7 @@ where
     R: Rng,
     G: RangeGenerator,
 {
+    #[allow(dead_code)]
     pub fn new(rng: R, band_range_gen: G, band_size: usize) -> Self {
         BandedRangeGenerator {
             uniform: Uniform::new(0, band_size),

--- a/finalfrontier/src/skipgram_trainer.rs
+++ b/finalfrontier/src/skipgram_trainer.rs
@@ -97,12 +97,12 @@ where
     fn try_into_input_vocab(self) -> Result<SubwordVocab, Error> {
         match Arc::try_unwrap(self.vocab) {
             Ok(vocab) => Ok(vocab),
-            Err(_) => return Err(err_msg("Cannot unwrap input vocab.")),
+            Err(_) => Err(err_msg("Cannot unwrap input vocab.")),
         }
     }
 
     fn n_input_types(&self) -> usize {
-        let n_buckets = 2usize.pow(self.config.buckets_exp as u32);
+        let n_buckets = 2usize.pow(self.config.buckets_exp);
         n_buckets + self.vocab.len()
     }
 

--- a/finalfrontier/src/train_model.rs
+++ b/finalfrontier/src/train_model.rs
@@ -117,6 +117,7 @@ impl<T> TrainModel<T> {
     }
 
     /// Get the input embedding with the given index.
+    #[allow(dead_code)]
     #[inline]
     pub(crate) fn input_embedding(&self, idx: usize) -> ArrayView1<f32> {
         self.input.subview(Axis(0), idx)
@@ -163,10 +164,14 @@ where
 
         // Compute and write word embeddings.
         let mut norms = vec![0f32; trainer.input_vocab().len()];
-        for i in 0..trainer.input_vocab().len() {
+        for (i, norm) in norms
+            .iter_mut()
+            .enumerate()
+            .take(trainer.input_vocab().len())
+        {
             let input = trainer.input_indices(i);
             let mut embed = Self::mean_embedding(input_matrix.view(), &input);
-            norms[i] = l2_normalize(embed.view_mut());
+            *norm = l2_normalize(embed.view_mut());
             input_matrix.index_axis_mut(Axis(0), i).assign(&embed);
         }
 

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -133,7 +133,7 @@ pub fn dot_unvectorized(u: &[f32], v: &[f32]) -> f32 {
     u.iter().zip(v).map(|(&a, &b)| a * b).sum()
 }
 
-#[allow(dead_code)]
+#[allow(dead_code, clippy::float_cmp)]
 unsafe fn scaled_add_f32x4(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
     assert_eq!(u.len(), v.len());
 
@@ -209,6 +209,7 @@ unsafe fn scaled_add_f32x8(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32
     scaled_add_unvectorized(u, v, a);
 }
 
+#[allow(clippy::float_cmp)]
 fn scaled_add_unvectorized(u: &mut [f32], v: &[f32], a: f32) {
     assert_eq!(u.len(), v.len());
 
@@ -260,8 +261,8 @@ unsafe fn scale_f32x8(mut u: ArrayViewMut1<f32>, a: f32) {
 }
 
 fn scale_unvectorized(u: &mut [f32], a: f32) {
-    for i in 0..u.len() {
-        u[i] *= a;
+    for mut c in u {
+        *c *= a;
     }
 }
 

--- a/finalfrontier/src/vocab.rs
+++ b/finalfrontier/src/vocab.rs
@@ -215,6 +215,10 @@ impl From<SubwordVocab> for VocabWrap {
 pub trait Vocab {
     type VocabType;
 
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Get the number of entries in the vocabulary.
     fn len(&self) -> usize {
         self.types().len()


### PR DESCRIPTION
I marked some methods as dead code. We should either expose
them (e.g. the range generators through an ff-train argument) or
remove them sometime soon.