### PR TITLE
Changes to seperate different types of hyperparameters.

### DIFF
--- a/finalfrontier/src/config.rs
+++ b/finalfrontier/src/config.rs
@@ -45,28 +45,11 @@ impl LossType {
     }
 }
 
-/// Embedding model hyperparameters.
+/// Common embedding model hyperparameters.
 #[derive(Clone, Copy, Debug, Serialize)]
-pub struct Config {
-    /// The model type.
-    pub model: ModelType,
-
+pub struct CommonConfig {
     /// The loss function used for the model.
     pub loss: LossType,
-
-    /// The number of preceding and succeeding tokens that will be consider
-    /// as context during training.
-    ///
-    /// For example, a context size of 5 will consider the 5 tokens preceding
-    /// and the 5 tokens succeeding the focus token.
-    pub context_size: u32,
-
-    /// Discard threshold.
-    ///
-    /// The discard threshold is used to compute the discard probability of
-    /// a token. E.g. with a threshold of 0.00001 tokens with approximately
-    /// that probability will never be discarded.
-    pub discard_threshold: f32,
 
     /// Word embedding dimensionality.
     pub dims: u32,
@@ -74,12 +57,23 @@ pub struct Config {
     /// The number of training epochs.
     pub epochs: u32,
 
-    /// Minimum token count.
-    ///
-    /// No word-specific embeddings will be trained for tokens occurring less
-    /// than this count.
-    pub min_count: u32,
+    /// Number of negative samples to use for each context word.
+    pub negative_samples: u32,
 
+    /// The initial learning rate.
+    pub lr: f32,
+
+    /// Exponent in zipfian distribution.
+    ///
+    /// This is s in *f(k) = 1 / (k^s H_{N, s})*.
+    pub zipf_exponent: f64,
+}
+
+/// Hyperparameters for subword-vocabs.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename = "SubwordVocab")]
+#[serde(tag = "type")]
+pub struct SubwordVocabConfig {
     /// Minimum n-gram length for subword units (inclusive).
     pub min_n: u32,
 
@@ -92,14 +86,51 @@ pub struct Config {
     /// buckets.
     pub buckets_exp: u32,
 
-    /// Number of negative samples to use for each context word.
-    pub negative_samples: u32,
-
-    /// The initial learning rate.
-    pub lr: f32,
-
-    /// Exponent in zipfian distribution.
+    /// Minimum token count.
     ///
-    /// This is s in *f(k) = 1 / (k^s H_{N, s})*.
-    pub zipf_exponent: f64,
+    /// No word-specific embeddings will be trained for tokens occurring less
+    /// than this count.
+    pub min_count: u32,
+
+    /// Discard threshold.
+    ///
+    /// The discard threshold is used to compute the discard probability of
+    /// a token. E.g. with a threshold of 0.00001 tokens with approximately
+    /// that probability will never be discarded.
+    pub discard_threshold: f32,
+}
+
+/// Hyperparameters for simple vocabs.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename = "SimpleVocab")]
+#[serde(tag = "type")]
+pub struct SimpleVocabConfig {
+    /// Minimum token count.
+    ///
+    /// No word-specific embeddings will be trained for tokens occurring less
+    /// than this count.
+    pub min_count: u32,
+
+    /// Discard threshold.
+    ///
+    /// The discard threshold is used to compute the discard probability of
+    /// a token. E.g. with a threshold of 0.00001 tokens with approximately
+    /// that probability will never be discarded.
+    pub discard_threshold: f32,
+}
+
+/// Hyperparameters for SkipGram-like models.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(tag = "type")]
+#[serde(rename = "SkipGramLike")]
+pub struct SkipGramConfig {
+    /// The model type.
+    pub model: ModelType,
+
+    /// The number of preceding and succeeding tokens that will be consider
+    /// as context during training.
+    ///
+    /// For example, a context size of 5 will consider the 5 tokens preceding
+    /// and the 5 tokens succeeding the focus token.
+    pub context_size: u32,
 }

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -37,7 +37,9 @@ extern crate toml;
 extern crate zipf;
 
 mod config;
-pub use config::{Config, LossType, ModelType};
+pub use config::{
+    CommonConfig, LossType, ModelType, SimpleVocabConfig, SkipGramConfig, SubwordVocabConfig,
+};
 
 mod deps;
 

--- a/finalfrontier/src/sgd.rs
+++ b/finalfrontier/src/sgd.rs
@@ -19,7 +19,10 @@ pub struct SGD<T> {
     sgd_impl: NegativeSamplingSGD,
 }
 
-impl<T> SGD<T> {
+impl<T> SGD<T>
+where
+    T: Trainer,
+{
     pub fn into_model(self) -> TrainModel<T> {
         self.model
     }


### PR DESCRIPTION
This PR looks bigger than it is. Mostly hyperparameters are moved around. Since changes to the config mean changes throughout the entire crate, this commit changes quite a number of files.

To allow more flexibility with different configurations, the `Config` is split up into several specialized structs holding only the hyperparameters relevant to each component.

The `CommonConfig` struct holds those hyperparameters that (at this point?) are shared by all training variants, including e.g. `dims`, `negative_samples` and `loss_type`.
 
Additionally, there are two config structs for vocabularies: `SimpleVocabConfig` and `SubwordVocabConfig`, holding the relevant hyperparameters.

Finally, there is the `SkipgramConfig` which holds settings relevant to skipgram-like training routines, i.e. the `context_window` and `model_type` determining whether vanilla `skipgram` is used or `structgram`.

Since different `Trainer` instantiations can and will have different sets of configurations, changes were necessary to the `WriteModelBinary` impl on `Trainmodel`, too. Instead of converting the `Config` of the `Trainmodel` to a `toml::Value`, `Trainer` now defines a metadata method

```Rust
/// Get this Trainer's hyperparameters as `toml::Value`.
fn to_metadata(&self) -> Result<Value, Error>;
```

leaving it to the `Trainer` implementations to take care of the conversion.

The `SkipgramTrainer`'s takes care of this conversion through an additional struct:

```Rust
#[derive(Clone, Copy, Debug, Serialize)]
struct SkipgramMetadata<V>
where
    V: Serialize,
{
    common_config: CommonConfig,
    #[serde(rename = "model_config")]
    skipgram_config: SkipGramConfig,
    vocab_config: V,
}
```

which is converted to a `toml::Value`.

This framework is compatible with training dependency embeddings without requiring a lot of additional changes. The next steps in my mind are to make the `SkipgramTrainer`'s input vocabulary generic, then adjust `ff-train` accordingly and finally introduce the `DepembedsTrainer` in a third PR. After the `DepembedsTrainer` is there, only minor changes would be left to `ff-train` (or a decision to split things into different crates/binaries). 