### PR TITLE
Migrate to Rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: rust
 rust:
+  - 1.31.0
   - stable
   - beta
   - nightly
 matrix:
+  fast_finish: true
   allow_failures:
     - rust: nightly
 before_script:

--- a/finalfrontier-utils/Cargo.toml
+++ b/finalfrontier-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "finalfrontier-utils"
 version = "0.4.0"
+edition = "2018"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 description = "Train and use word embeddings with subword representations"
 documentation = "https://git.danieldk.eu/finalfrontier/about"

--- a/finalfrontier-utils/src/bin/ff-train.rs
+++ b/finalfrontier-utils/src/bin/ff-train.rs
@@ -1,12 +1,3 @@
-extern crate clap;
-extern crate finalfrontier;
-extern crate finalfrontier_utils;
-extern crate indicatif;
-extern crate num_cpus;
-extern crate rand;
-extern crate rand_xorshift;
-extern crate stdinout;
-
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};

--- a/finalfrontier-utils/src/lib.rs
+++ b/finalfrontier-utils/src/lib.rs
@@ -1,11 +1,5 @@
-extern crate failure;
-
-extern crate indicatif;
-
-extern crate memmap;
-
 mod data;
-pub use data::thread_data;
+pub use crate::data::thread_data;
 
 mod progress;
 pub use crate::progress::FileProgress;

--- a/finalfrontier/Cargo.toml
+++ b/finalfrontier/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "finalfrontier"
 version = "0.4.0"
+edition = "2018"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 description = "Train/use word embeddings with subword units"
 documentation = "https://docs.rs/finalfrontier/"

--- a/finalfrontier/src/deps.rs
+++ b/finalfrontier/src/deps.rs
@@ -297,12 +297,12 @@ where
 mod tests {
     use std::io::Cursor;
 
+    use crate::deps::DepIter;
+    use crate::deps::Dependency;
+    use crate::deps::Dependency::Untyped;
+    use crate::deps::{DependencyIterator, PathIter};
     use conllx::graph::Node;
     use conllx::io::{ReadSentence, Reader};
-    use deps::DepIter;
-    use deps::Dependency;
-    use deps::Dependency::Untyped;
-    use deps::{DependencyIterator, PathIter};
 
     static DEP: &[u8; 143] = b"1	Er	a	_	_	_	2	SUBJ	_	_\n\
     2	geht	b	_	_	_	0	ROOT	_	_\n\
@@ -328,7 +328,7 @@ mod tests {
         let g = sentence.dep_graph();
         assert_eq!(g.len() - 1, v.len());
         for (target, node) in v.into_iter().zip(1..g.len()) {
-            let mut path = g.path_iter(node);
+            let path = g.path_iter(node);
             assert_eq!(
                 path.map(|triple| triple.head())
                     .map(|head| match &g[head] {

--- a/finalfrontier/src/io.rs
+++ b/finalfrontier/src/io.rs
@@ -1,7 +1,8 @@
 use std::io::{self, BufRead, Lines, Write};
 
 use failure::Error;
-use util::EOS;
+
+use crate::util::EOS;
 
 /// Sentence iterator.
 ///
@@ -96,7 +97,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::SentenceIterator;
-    use util::EOS;
+    use crate::util::EOS;
 
     #[test]
     fn sentence_iterator_test() {

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -1,69 +1,31 @@
-#[macro_use]
-extern crate cfg_if;
-
-extern crate conllx;
-
-extern crate failure;
-
-extern crate finalfusion;
-
-extern crate fnv;
-
-extern crate hogwild;
-
-#[macro_use]
-#[cfg(test)]
-extern crate lazy_static;
-
-#[macro_use]
-#[cfg(test)]
-extern crate maplit;
-
-extern crate ndarray;
-
-extern crate ndarray_rand;
-
-extern crate rand;
-
-extern crate rand_core;
-
-#[cfg(test)]
-extern crate rand_xorshift;
-
-extern crate serde;
-
-extern crate toml;
-
-extern crate zipf;
-
 mod config;
-pub use config::{
+pub use crate::config::{
     CommonConfig, LossType, ModelType, SimpleVocabConfig, SkipGramConfig, SubwordVocabConfig,
 };
 
 mod deps;
 
 mod io;
-pub use io::{SentenceIterator, WriteModelBinary, WriteModelText, WriteModelWord2Vec};
+pub use crate::io::{SentenceIterator, WriteModelBinary, WriteModelText, WriteModelWord2Vec};
 
 pub(crate) mod loss;
 
 pub(crate) mod sampling;
 
 mod sgd;
-pub use sgd::SGD;
+pub use crate::sgd::SGD;
 
 pub(crate) mod subword;
 
 mod train_model;
-pub use train_model::{TrainModel, Trainer};
+pub use crate::train_model::{TrainModel, Trainer};
 
 pub(crate) mod skipgram_trainer;
-pub use skipgram_trainer::SkipgramTrainer;
+pub use crate::skipgram_trainer::SkipgramTrainer;
 
 pub(crate) mod util;
 
 pub(crate) mod vec_simd;
 
 mod vocab;
-pub use vocab::{CountedType, SubwordVocab, Vocab, VocabBuilder, Word};
+pub use crate::vocab::{CountedType, SubwordVocab, Vocab, VocabBuilder, Word};

--- a/finalfrontier/src/loss.rs
+++ b/finalfrontier/src/loss.rs
@@ -1,7 +1,7 @@
 use ndarray::ArrayView1;
 
-use util;
-use vec_simd::dot;
+use crate::util;
+use crate::vec_simd::dot;
 
 /// Absolute activations to round in logistic regression.
 ///
@@ -104,7 +104,7 @@ fn logistic_function(a: f32) -> f32 {
 mod tests {
     use ndarray::Array1;
 
-    use util::{all_close, close};
+    use crate::util::{all_close, close};
 
     use super::{log_logistic_loss, logistic_function};
 

--- a/finalfrontier/src/sampling.rs
+++ b/finalfrontier/src/sampling.rs
@@ -210,7 +210,7 @@ mod tests {
     use rand_xorshift::XorShiftRng;
 
     use super::{BandedRangeGenerator, RangeGenerator, WeightedRangeGenerator, ZipfRangeGenerator};
-    use util::{all_close, close};
+    use crate::util::{all_close, close};
 
     const SEED: [u8; 16] = [
         0xe9, 0xfe, 0xf0, 0xfb, 0x6a, 0x23, 0x2a, 0xb3, 0x7c, 0xce, 0x27, 0x9b, 0x56, 0xac, 0xdb,

--- a/finalfrontier/src/sgd.rs
+++ b/finalfrontier/src/sgd.rs
@@ -1,11 +1,11 @@
 use ndarray::{Array1, ArrayView1, ArrayViewMut1};
 
+use crate::loss::log_logistic_loss;
+use crate::train_model::{NegativeSamples, TrainIterFrom, Trainer};
+use crate::vec_simd::scaled_add;
 use hogwild::Hogwild;
-use loss::log_logistic_loss;
-use train_model::{NegativeSamples, TrainIterFrom, Trainer};
-use vec_simd::scaled_add;
 
-use TrainModel;
+use crate::TrainModel;
 
 /// Stochastic gradient descent
 ///
@@ -153,7 +153,7 @@ impl NegativeSamplingSGD {
 
         // Update the input embeddings with the accumulated gradient.
         for &idx in input {
-            let mut input_embed = model.input_embedding_mut(idx as usize);
+            let input_embed = model.input_embedding_mut(idx as usize);
             scaled_add(input_embed, input_delta.view(), 1.0);
         }
 

--- a/finalfrontier/src/skipgram_trainer.rs
+++ b/finalfrontier/src/skipgram_trainer.rs
@@ -6,9 +6,9 @@ use failure::{err_msg, Error};
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
 
-use train_model::{NegativeSamples, TrainIterFrom, Trainer};
-use util::ReseedOnCloneRng;
-use {CommonConfig, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabConfig, Vocab};
+use crate::train_model::{NegativeSamples, TrainIterFrom, Trainer};
+use crate::util::ReseedOnCloneRng;
+use crate::{CommonConfig, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabConfig, Vocab};
 
 /// Skipgram Trainer
 ///

--- a/finalfrontier/src/subword.rs
+++ b/finalfrontier/src/subword.rs
@@ -113,6 +113,9 @@ impl SubwordIndices for str {
 mod tests {
     use std::collections::HashMap;
 
+    use lazy_static::lazy_static;
+    use maplit::hashmap;
+
     use super::{NGrams, SubwordIndices};
 
     #[test]

--- a/finalfrontier/src/train_model.rs
+++ b/finalfrontier/src/train_model.rs
@@ -13,9 +13,9 @@ use ndarray_rand::RandomExt;
 use rand::distributions::Uniform;
 use serde::Serialize;
 use toml::Value;
-use vec_simd::{l2_normalize, scale, scaled_add};
 
-use {CommonConfig, Vocab, WriteModelBinary};
+use crate::vec_simd::{l2_normalize, scale, scaled_add};
+use crate::{CommonConfig, Vocab, WriteModelBinary};
 
 /// Training model.
 ///
@@ -250,9 +250,9 @@ mod tests {
     use rand_xorshift::XorShiftRng;
 
     use super::TrainModel;
-    use skipgram_trainer::SkipgramTrainer;
-    use util::all_close;
-    use {
+    use crate::skipgram_trainer::SkipgramTrainer;
+    use crate::util::all_close;
+    use crate::{
         CommonConfig, LossType, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabConfig,
         VocabBuilder,
     };

--- a/finalfrontier/src/vec_simd.rs
+++ b/finalfrontier/src/vec_simd.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use ndarray::{ArrayView1, ArrayViewMut1};
 
 #[cfg(target_arch = "x86")]
@@ -261,7 +262,7 @@ unsafe fn scale_f32x8(mut u: ArrayViewMut1<f32>, a: f32) {
 }
 
 fn scale_unvectorized(u: &mut [f32], a: f32) {
-    for mut c in u {
+    for c in u {
         *c *= a;
     }
 }
@@ -282,7 +283,7 @@ mod tests {
     use ndarray_rand::RandomExt;
     use rand::distributions::Uniform;
 
-    use util::{all_close, array_all_close, close};
+    use crate::util::{all_close, array_all_close, close};
 
     use super::{
         dot_f32x4, dot_unvectorized, l2_normalize, scale_f32x4, scale_unvectorized,

--- a/finalfrontier/src/vocab.rs
+++ b/finalfrontier/src/vocab.rs
@@ -6,8 +6,8 @@ use finalfusion::vocab::{
     SimpleVocab as FiFuSimpleVocab, SubwordVocab as FiFuSubwordVocab, VocabWrap,
 };
 
-use subword::SubwordIndices;
-use {util, SimpleVocabConfig, SubwordVocabConfig};
+use crate::subword::SubwordIndices;
+use crate::{util, SimpleVocabConfig, SubwordVocabConfig};
 
 const BOW: char = '<';
 const EOW: char = '>';
@@ -441,8 +441,8 @@ fn bracket(word: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{bracket, SimpleVocab, SubwordVocab, Vocab, VocabBuilder};
-    use subword::SubwordIndices;
-    use {util, SimpleVocabConfig, SubwordVocabConfig};
+    use crate::subword::SubwordIndices;
+    use crate::{util, SimpleVocabConfig, SubwordVocabConfig};
 
     const TEST_SUBWORDCONFIG: SubwordVocabConfig = SubwordVocabConfig {
         buckets_exp: 21,

--- a/hogwild/Cargo.toml
+++ b/hogwild/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hogwild"
 version = "0.4.0"
+edition = "2018"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 description = "Data types for hogwild SGD"
 documentation = "https://docs.rs/hogwild/"

--- a/hogwild/src/lib.rs
+++ b/hogwild/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate ndarray;
-
 use std::cell::UnsafeCell;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -25,9 +23,6 @@ use ndarray::{Array, ArrayView, ArrayViewMut, Axis, Dimension, Ix, Ix1, Ix2, Ix3
 /// # Example
 ///
 /// ```
-/// extern crate hogwild;
-/// extern crate ndarray;
-///
 /// use hogwild::HogwildArray2;
 /// use ndarray::Array2;
 ///


### PR DESCRIPTION
We were still implicitly on Rust 2015, while at the same time using
post-2018 features. So:

- Switch to Rust 2018
- Also do CI builds on Rust 1.31

The motivation to also test builds against 1.31 is that this is the
first Rust version that supports 2018. Later versions have changes
that are not strictly Rust 2018. I want to stick to 1.31/2018 as the
lowest common denominator for a while, since Linux distributions are
sometimes trailing in Rust versions.