### PR TITLE
Automatically build release binaries for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: rust
-rust:
-  - 1.31.0
-  - stable
-  - beta
-  - nightly
+env:
+  global:
+    - PROJECT_NAME: finalfrontier
 matrix:
   fast_finish: true
+  include:
+    - os: linux
+      rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+    - os: osx
+      rust: stable
+      env: TARGET=x86_64-apple-darwin
+    - os: linux
+      rust: 1.31.0
+    - os: linux
+      rust: nightly
   allow_failures:
-    - rust: nightly
+  - rust: nightly
 before_script:
   - rustup component add clippy
   - rustup component add rustfmt
@@ -16,3 +25,15 @@ script:
   - cargo build
   - cargo test
   - cargo clippy
+before_deploy: ci/before_deploy.sh
+deploy:
+  provider: releases
+  api_key:
+    secure: xnZPmJSADTRlfTm4G2u5182tJwqTr0SziIUPZ4uFg7Hfowf0LwwzJSt+Va4gBslEzxbdb/iT3cDXQpiKnOCcwLbtX+SqE6PsO3C66NYL1ff1VghKn8gNdPD9kERXydc6exAxGQ8tB81tOreXXuYC2X2nuqFDmwE5hsTjifg2gDrFjQwFcgcmnmRYgw6SwSeBb4JllFAr5kKLRafqznuvX39eIkxGqXc1EtRIA2M2wZWqVPcgolKut0KPm7RjuCWc8kgAG1Co5/kjtcG4uTSoz8HNTKfZRNM2IemQDUZr2BND2MYj/DC626JZHFXnjV/4+pTByI3iigZV+EuLNThZzepbomL3Y0ITVgrycbExwncITjkXTqSQrubx2C8ZmRQgPIWufDXgIaPLHx2BgF1r0Tya14ST8YMkCRQkfwAMiuIdwVZXATYM2BRAQi1RCfIhPQrTuWWRFSrZChhBNFMu8vUB4NB3szDLGr8/WOINIr2f7T/4/Q7fFbsEnAVDJCEdpvuwj7qTvXB11V4OQO9n28DCRyPwxHNjThgwcIEd1tZPtRYOMX1wHxeTzo1rpSNgqvRtfKvIL+ICTJN9Dp3yyKe5e8UAGFT7FEKsvjaSKOo3/8qHVKd0oCtqy+Uhyf07GnjP95BolgfAxwqI6bVKMFm/YZxRELlPOafXS0799Vg=
+  file_glob: true
+  file: deployment/${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}.tar.gz
+  skip_cleanup: true
+  on:
+    condition: $TRAVIS_RUST_VERSION = stable
+    repo: finalfusion/finalfrontier
+    tags: true

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+cargo build --target "$TARGET" --release
+
+tmpdir="$(mktemp -d)"
+name="${PROJECT_NAME}-${TRAVIS_TAG}-${TARGET}"
+staging="${tmpdir}/${name}"
+mkdir "${staging}"
+out_dir="$(pwd)/deployment"
+mkdir "${out_dir}"
+
+cp "target/${TARGET}/release/ff-train" "${staging}/ff-train"
+strip "${staging}/ff-train"
+cp {README.md,LICENSE,NOTICE} "${staging}/"
+
+( cd "${tmpdir}" && tar czf "${out_dir}/${name}.tar.gz" "${name}")
+
+rm -rf "${tmpdir}"


### PR DESCRIPTION
Perform Linux and macOS 86_64 release builds for git tags and upload them to GitHub releases.