### PR TITLE
Add AppStructs for Depembeds and SkipGram.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ name = "finalfrontier-utils"
 version = "0.4.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conllx 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfrontier 0.4.0",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/finalfrontier-utils/Cargo.toml
+++ b/finalfrontier-utils/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 
 [dependencies]
 clap = "2"
+conllx = "0.11"
 failure = "0.1"
 finalfrontier = { path = "../finalfrontier", version = "0.4.0" }
 indicatif = "0.11"

--- a/finalfrontier-utils/src/lib.rs
+++ b/finalfrontier-utils/src/lib.rs
@@ -5,7 +5,4 @@ mod progress;
 pub use crate::progress::FileProgress;
 
 mod util;
-pub use crate::util::{
-    common_config_from_matches, show_progress, skipgram_config_from_matches,
-    subword_config_from_matches, AppBuilder,
-};
+pub use crate::util::{show_progress, DepembedsApp, SkipGramApp};


### PR DESCRIPTION
Rather light weight changes with lots of lines.

While implementing the `ff-deps` binary I realized I didn't really like the same `AppBuilder` for both training types. I defined `SkipGramApp` and `DepembedsApp` structs that handle all clap-related business and construct all the required configs. The required configs and values can be accessed through getter methods.

Next step after this PR is the actual binary, then clean up (there were some incorrect docs somewhere in the `dep` module)  and we should be ready to release.