### PR TITLE
Add projectivization switch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "conllx"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -208,7 +208,7 @@ name = "finalfrontier"
 version = "0.4.0"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "conllx 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conllx 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfusion 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -230,7 +230,7 @@ name = "finalfrontier-utils"
 version = "0.4.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conllx 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conllx 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfrontier 0.4.0",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,7 +880,7 @@ dependencies = [
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum conllx 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba38ab4b11523f720290e83c113e8a38659460a485961954ef4e4d71776afbf3"
+"checksum conllx 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4b56ce06073dad27db862b267b7bf02a2f84ae0d21951808afc6cd6caec0f79b"
 "checksum console 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2bf3720d3f3fc30b721ef1ae54e13af3264af4af39dc476a8de56a6ee1e2184b"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"

--- a/finalfrontier-utils/src/util.rs
+++ b/finalfrontier-utils/src/util.rs
@@ -32,6 +32,7 @@ static MODEL: &str = "model";
 static UNTYPED_DEPS: &str = "untyped";
 static NORMALIZE_CONTEXT: &str = "normalize";
 static NS: &str = "ns";
+static PROJECTIVIZE: &str = "projectivize";
 static THREADS: &str = "threads";
 static USE_ROOT: &str = "use_root";
 static ZIPF_EXPONENT: &str = "zipf";
@@ -251,7 +252,7 @@ impl DepembedsApp {
         .arg(
             Arg::with_name(UNTYPED_DEPS)
                 .long("untyped_deps")
-                .help("Don't use dependency relation labels"),
+                .help("Don't use dependency relation labels."),
         )
         .arg(
             Arg::with_name(NORMALIZE_CONTEXT)
@@ -259,9 +260,14 @@ impl DepembedsApp {
                 .help("Normalize contexts"),
         )
         .arg(
+            Arg::with_name(PROJECTIVIZE)
+                .long("projectivize")
+                .help("Projectivize dependency graphs before training."),
+        )
+        .arg(
             Arg::with_name(USE_ROOT)
                 .long("use_root")
-                .help("Use root when extracting dependency contexts"),
+                .help("Use root when extracting dependency contexts."),
         )
     }
 
@@ -272,11 +278,13 @@ impl DepembedsApp {
             .unwrap_or(1);
         let untyped = matches.is_present(UNTYPED_DEPS);
         let normalize = matches.is_present(NORMALIZE_CONTEXT);
+        let projectivize = matches.is_present(PROJECTIVIZE);
         let use_root = matches.is_present(USE_ROOT);
         DepembedsConfig {
             depth,
             untyped,
             normalize,
+            projectivize,
             use_root,
         }
     }

--- a/finalfrontier/src/config.rs
+++ b/finalfrontier/src/config.rs
@@ -83,6 +83,9 @@ pub struct DepembedsConfig {
     /// Lowercase all tokens when used as context.
     pub normalize: bool,
 
+    /// Projectivize dependency graphs before training.
+    pub projectivize: bool,
+
     /// Extract untyped dependency contexts.
     ///
     /// Only takes the attached word-form into account.

--- a/finalfrontier/src/dep_trainer.rs
+++ b/finalfrontier/src/dep_trainer.rs
@@ -26,6 +26,12 @@ pub struct DepembedsTrainer<R> {
     rng: R,
 }
 
+impl<R> DepembedsTrainer<R> {
+    pub fn dep_config(&self) -> DepembedsConfig {
+        self.dep_config
+    }
+}
+
 impl<R> DepembedsTrainer<ReseedOnCloneRng<R>>
 where
     R: Rng + Clone + SeedableRng,


### PR DESCRIPTION
Adds option to projectivize dependency graphs before training.

This is all a bit messier than I hoped. With how the binaries are structured at this point, I couldn't come up with a nice abstraction.  For now we could stick with some wrapper struct holding an optional projectivizer:

```Rust
struct SentenceIter<P, R> {
    inner: Reader<R>,
    projectivizer: Option<P>,
}
```
and implement `Iterator<Item = Sentence>` for it.

There's some ugliness in the `do_work` method because `HeadProjectivizer` doesn't derive `Copy + Clone`.