### PR TITLE
Change Vocab and Trainers to prepare non-subword training. [Idx enum]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/finalfrontier-utils/Cargo.toml
+++ b/finalfrontier-utils/Cargo.toml
@@ -20,3 +20,4 @@ num_cpus = "1"
 rand = "0.6"
 rand_xorshift = "0.1"
 stdinout = "0.4"
+serde = { version = "1", features = ["derive"] }

--- a/finalfrontier-utils/src/bin/ff-train-skipgram.rs
+++ b/finalfrontier-utils/src/bin/ff-train-skipgram.rs
@@ -11,6 +11,7 @@ use finalfrontier::{
 use finalfrontier_utils::{show_progress, thread_data_text, FileProgress, SkipGramApp};
 use rand::{FromEntropy, Rng};
 use rand_xorshift::XorShiftRng;
+use serde::Serialize;
 use stdinout::OrExit;
 
 const PROGRESS_UPDATE_INTERVAL: u64 = 200;
@@ -65,9 +66,9 @@ fn main() {
         .or_exit("Cannot write model", 1);
 }
 
-fn do_work<P, R>(
+fn do_work<P, R, V>(
     corpus_path: P,
-    mut sgd: SGD<SkipgramTrainer<R>>,
+    mut sgd: SGD<SkipgramTrainer<R, V>>,
     thread: usize,
     n_threads: usize,
     epochs: u32,
@@ -75,6 +76,8 @@ fn do_work<P, R>(
 ) where
     P: Into<PathBuf>,
     R: Clone + Rng,
+    V: Vocab<VocabType = String>,
+    V::Config: Serialize,
 {
     let n_tokens = sgd.model().input_vocab().n_types();
 

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -33,4 +33,6 @@ pub(crate) mod util;
 pub(crate) mod vec_simd;
 
 mod vocab;
-pub use crate::vocab::{CountedType, SimpleVocab, SubwordVocab, Vocab, VocabBuilder, Word};
+pub use crate::vocab::{
+    CountedType, SimpleVocab, SubwordVocab, Vocab, VocabBuilder, Word, WordIdx,
+};

--- a/finalfrontier/src/train_model.rs
+++ b/finalfrontier/src/train_model.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 use toml::Value;
 
 use crate::vec_simd::{l2_normalize, scale, scaled_add};
-use crate::{CommonConfig, Vocab, WriteModelBinary};
+use crate::{CommonConfig, Vocab, WordIdx, WriteModelBinary};
 
 /// Training model.
 ///
@@ -56,7 +56,7 @@ where
         let distribution = Uniform::new_inclusive(-init_bound, init_bound);
 
         let input = Array2::random(
-            (trainer.n_input_types(), config.dims as usize),
+            (trainer.input_vocab().n_input_types(), config.dims as usize),
             distribution,
         )
         .into();
@@ -101,15 +101,18 @@ impl<T> TrainModel<T> {
     }
 
     /// Get the mean input embedding of the given indices.
-    pub(crate) fn mean_input_embedding(&self, indices: &[u64]) -> Array1<f32> {
-        Self::mean_embedding(self.input.view(), indices)
+    pub(crate) fn mean_input_embedding(&self, idx: &WordIdx) -> Array1<f32> {
+        match idx {
+            WordIdx::Word(idx) => self.input.subview(Axis(0), *idx as usize).to_owned(),
+            WordIdx::WordWithSubwords(_) => Self::mean_embedding(self.input.view(), idx),
+        }
     }
 
     /// Get the mean input embedding of the given indices.
-    fn mean_embedding(embeds: ArrayView2<f32>, indices: &[u64]) -> Array1<f32> {
+    fn mean_embedding(embeds: ArrayView2<f32>, indices: &WordIdx) -> Array1<f32> {
         let mut embed = Array1::zeros((embeds.cols(),));
 
-        for &idx in indices.iter() {
+        for idx in indices {
             scaled_add(
                 embed.view_mut(),
                 embeds.index_axis(Axis(0), idx as usize),
@@ -162,6 +165,7 @@ where
     W: Seek + Write,
     T: Trainer<InputVocab = V, Metadata = M>,
     V: Vocab + Into<VocabWrap>,
+    V::VocabType: ToString,
     M: Serialize,
 {
     fn write_model_binary(self, write: &mut W) -> Result<(), Error> {
@@ -171,13 +175,17 @@ where
 
         // Compute and write word embeddings.
         let mut norms = vec![0f32; trainer.input_vocab().len()];
-        for (i, norm) in norms
+        for (i, (norm, word)) in norms
             .iter_mut()
-            .enumerate()
+            .zip(trainer.input_vocab().types())
             .take(trainer.input_vocab().len())
+            .enumerate()
         {
-            let input = trainer.input_indices(i);
-            let mut embed = Self::mean_embedding(input_matrix.view(), &input);
+            let input = trainer.input_vocab().idx(word.label()).unwrap();
+            let mut embed = match input {
+                WordIdx::WordWithSubwords(_) => Self::mean_embedding(input_matrix.view(), &input),
+                WordIdx::Word(idx) => input_matrix.row(idx as usize).to_owned(),
+            };
             *norm = l2_normalize(embed.view_mut());
             input_matrix.index_axis_mut(Axis(0), i).assign(&embed);
         }
@@ -194,9 +202,6 @@ where
 pub trait Trainer {
     type InputVocab: Vocab;
     type Metadata;
-
-    /// Given an input index get all associated indices.
-    fn input_indices(&self, idx: usize) -> Vec<u64>;
 
     /// Get the trainer's input vocabulary.
     fn input_vocab(&self) -> &Self::InputVocab;
@@ -230,8 +235,8 @@ pub trait TrainIterFrom<S>
 where
     S: ?Sized,
 {
-    type Iter: Iterator<Item = (usize, Self::Contexts)>;
-    type Contexts: Sized + IntoIterator<Item = usize>;
+    type Iter: Iterator<Item = (WordIdx, Self::Contexts)>;
+    type Contexts: IntoIterator<Item = usize>;
 
     fn train_iter_from(&mut self, sequence: &S) -> Self::Iter;
 }
@@ -255,7 +260,7 @@ mod tests {
     use crate::util::all_close;
     use crate::{
         CommonConfig, LossType, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabConfig,
-        VocabBuilder,
+        VocabBuilder, WordIdx,
     };
 
     const TEST_COMMON_CONFIG: CommonConfig = CommonConfig {
@@ -360,7 +365,10 @@ mod tests {
 
         // Mean input embedding.
         assert!(all_close(
-            model.mean_input_embedding(&[0, 1]).as_slice().unwrap(),
+            model
+                .mean_input_embedding(&WordIdx::WordWithSubwords((0, vec![1])))
+                .as_slice()
+                .unwrap(),
             &[2.5, 3.5, 4.5],
             1e-5
         ));


### PR DESCRIPTION
First commit to allow training without subwords. Adds the Idx enum representing a Single or Multiple indices.

I think this is cleaner than the original proposition in #13, there are probably still a few things to discuss, but I hope this is going in the right direction.