### PR TITLE
Change Vocab and Trainers to prepare non-subword training. [Idx Trait]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/finalfrontier-utils/Cargo.toml
+++ b/finalfrontier-utils/Cargo.toml
@@ -20,3 +20,4 @@ num_cpus = "1"
 rand = "0.6"
 rand_xorshift = "0.1"
 stdinout = "0.4"
+serde = { version = "1", features = ["derive"] }

--- a/finalfrontier-utils/src/bin/ff-train-skipgram.rs
+++ b/finalfrontier-utils/src/bin/ff-train-skipgram.rs
@@ -11,6 +11,7 @@ use finalfrontier::{
 use finalfrontier_utils::{show_progress, thread_data_text, FileProgress, SkipGramApp};
 use rand::{FromEntropy, Rng};
 use rand_xorshift::XorShiftRng;
+use serde::Serialize;
 use stdinout::OrExit;
 
 const PROGRESS_UPDATE_INTERVAL: u64 = 200;
@@ -65,9 +66,9 @@ fn main() {
         .or_exit("Cannot write model", 1);
 }
 
-fn do_work<P, R>(
+fn do_work<P, R, V>(
     corpus_path: P,
-    mut sgd: SGD<SkipgramTrainer<R>>,
+    mut sgd: SGD<SkipgramTrainer<R, V>>,
     thread: usize,
     n_threads: usize,
     epochs: u32,
@@ -75,6 +76,8 @@ fn do_work<P, R>(
 ) where
     P: Into<PathBuf>,
     R: Clone + Rng,
+    V: Vocab<VocabType = String>,
+    V::Config: Serialize,
 {
     let n_tokens = sgd.model().input_vocab().n_types();
 

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -33,4 +33,4 @@ pub(crate) mod util;
 pub(crate) mod vec_simd;
 
 mod vocab;
-pub use crate::vocab::{CountedType, SimpleVocab, SubwordVocab, Vocab, VocabBuilder, Word};
+pub use crate::vocab::{CountedType, Idx, SimpleVocab, SubwordVocab, Vocab, VocabBuilder, Word};

--- a/finalfrontier/src/skipgram_trainer.rs
+++ b/finalfrontier/src/skipgram_trainer.rs
@@ -1,6 +1,8 @@
-use std::cmp;
+use std::borrow::Borrow;
+use std::hash::Hash;
 use std::iter::FusedIterator;
 use std::sync::Arc;
+use std::{cmp, mem};
 
 use failure::{err_msg, Error};
 use rand::{Rng, SeedableRng};
@@ -9,7 +11,7 @@ use serde::Serialize;
 use crate::sampling::{BandedRangeGenerator, ZipfRangeGenerator};
 use crate::train_model::{NegativeSamples, TrainIterFrom, Trainer};
 use crate::util::ReseedOnCloneRng;
-use crate::{CommonConfig, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabConfig, Vocab};
+use crate::{CommonConfig, Idx, ModelType, SkipGramConfig, Vocab};
 
 /// Skipgram Trainer
 ///
@@ -17,21 +19,22 @@ use crate::{CommonConfig, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabC
 /// sentence into an iterator of focus and context tuples. The struct is cheap to clone because
 /// the vocabulary is shared between clones.
 #[derive(Clone)]
-pub struct SkipgramTrainer<R> {
-    vocab: Arc<SubwordVocab>,
+pub struct SkipgramTrainer<R, V> {
+    vocab: Arc<V>,
     rng: R,
     range_gen: BandedRangeGenerator<R, ZipfRangeGenerator<R>>,
     common_config: CommonConfig,
     skipgram_config: SkipGramConfig,
 }
 
-impl<R> SkipgramTrainer<ReseedOnCloneRng<R>>
+impl<R, V> SkipgramTrainer<ReseedOnCloneRng<R>, V>
 where
     R: Rng + Clone + SeedableRng,
+    V: Vocab,
 {
     /// Constructs a new `SkipgramTrainer`.
     pub fn new(
-        vocab: SubwordVocab,
+        vocab: V,
         rng: R,
         common_config: CommonConfig,
         skipgram_config: SkipGramConfig,
@@ -63,19 +66,22 @@ where
     }
 }
 
-impl<S, R> TrainIterFrom<[S]> for SkipgramTrainer<R>
+impl<S, R, V, I> TrainIterFrom<[S], I> for SkipgramTrainer<R, V>
 where
-    S: AsRef<str>,
+    S: Hash + Eq,
     R: Rng + Clone,
+    I: Idx,
+    V: Vocab<Idx = I>,
+    V::VocabType: Borrow<S>,
 {
-    type Iter = SkipGramIter<R>;
+    type Iter = SkipGramIter<R, I>;
     type Contexts = Vec<usize>;
 
     fn train_iter_from(&mut self, sequence: &[S]) -> Self::Iter {
         let mut ids = Vec::new();
         for t in sequence {
-            if let Some(idx) = self.vocab.idx(t.as_ref()) {
-                if self.rng.gen_range(0f32, 1f32) < self.vocab.discard(idx) {
+            if let Some(idx) = self.vocab.idx(t) {
+                if self.rng.gen_range(0f32, 1f32) < self.vocab.discard(idx.single_idx() as usize) {
                     ids.push(idx);
                 }
             }
@@ -84,7 +90,7 @@ where
     }
 }
 
-impl<R> NegativeSamples for SkipgramTrainer<R>
+impl<R, V> NegativeSamples for SkipgramTrainer<R, V>
 where
     R: Rng,
 {
@@ -98,24 +104,20 @@ where
     }
 }
 
-impl<R> Trainer for SkipgramTrainer<R>
+impl<R, V> Trainer for SkipgramTrainer<R, V>
 where
     R: Rng + Clone,
+    V: Vocab,
+    V::Config: Serialize,
 {
-    type InputVocab = SubwordVocab;
-    type Metadata = SkipgramMetadata<SubwordVocabConfig>;
+    type InputVocab = V;
+    type Metadata = SkipgramMetadata<V::Config>;
 
-    fn input_indices(&self, idx: usize) -> Vec<u64> {
-        let mut v = self.vocab.subword_indices_idx(idx).unwrap().to_vec();
-        v.push(idx as u64);
-        v
-    }
-
-    fn input_vocab(&self) -> &SubwordVocab {
+    fn input_vocab(&self) -> &V {
         &self.vocab
     }
 
-    fn try_into_input_vocab(self) -> Result<SubwordVocab, Error> {
+    fn try_into_input_vocab(self) -> Result<V, Error> {
         match Arc::try_unwrap(self.vocab) {
             Ok(vocab) => Ok(vocab),
             Err(_) => Err(err_msg("Cannot unwrap input vocab.")),
@@ -123,8 +125,7 @@ where
     }
 
     fn n_input_types(&self) -> usize {
-        let n_buckets = 2usize.pow(self.input_vocab().config().buckets_exp);
-        n_buckets + self.input_vocab().len()
+        self.input_vocab().n_input_types()
     }
 
     fn n_output_types(&self) -> usize {
@@ -141,7 +142,7 @@ where
         &self.common_config
     }
 
-    fn to_metadata(&self) -> SkipgramMetadata<SubwordVocabConfig> {
+    fn to_metadata(&self) -> SkipgramMetadata<V::Config> {
         SkipgramMetadata {
             common_config: self.common_config,
             skipgram_config: self.skipgram_config,
@@ -151,22 +152,23 @@ where
 }
 
 /// Iterator over focus identifier and associated context identifiers in a sentence.
-pub struct SkipGramIter<R> {
-    ids: Vec<usize>,
+pub struct SkipGramIter<R, I> {
+    ids: Vec<I>,
     rng: R,
     i: usize,
     model_type: ModelType,
     ctx_size: usize,
 }
 
-impl<R> SkipGramIter<R>
+impl<R, I> SkipGramIter<R, I>
 where
     R: Rng + Clone,
+    I: Idx,
 {
     /// Constructs a new `SkipGramIter`.
     ///
     /// The `rng` is used to determine the window size for each focus token.
-    pub fn new(rng: R, ids: Vec<usize>, skip_config: SkipGramConfig) -> Self {
+    pub fn new(rng: R, ids: Vec<I>, skip_config: SkipGramConfig) -> Self {
         SkipGramIter {
             ids,
             rng,
@@ -197,11 +199,12 @@ where
     }
 }
 
-impl<R> Iterator for SkipGramIter<R>
+impl<R, I> Iterator for SkipGramIter<R, I>
 where
     R: Rng + Clone,
+    I: Idx,
 {
-    type Item = (usize, Vec<usize>);
+    type Item = (I, Vec<usize>);
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.i < self.ids.len() {
@@ -211,19 +214,26 @@ where
             let right = cmp::min(self.i + context_size + 1, self.ids.len());
             let contexts = (left..right)
                 .filter(|&idx| idx != self.i)
-                .map(|idx| self.output_(self.ids[idx], self.i, idx))
+                .map(|idx| self.output_(self.ids[idx].single_idx() as usize, self.i, idx))
                 .fold(Vec::with_capacity(right - left), |mut contexts, idx| {
                     contexts.push(idx);
                     contexts
                 });
+            let mut word_idx = self.ids[self.i].to_single();
+            mem::swap(&mut self.ids[self.i], &mut word_idx);
             self.i += 1;
-            return Some((self.ids[self.i - 1], contexts));
+            return Some((word_idx, contexts));
         }
         None
     }
 }
 
-impl<R> FusedIterator for SkipGramIter<R> where R: Rng + Clone {}
+impl<R, I> FusedIterator for SkipGramIter<R, I>
+where
+    R: Rng + Clone,
+    I: Idx,
+{
+}
 
 /// Metadata for Skipgramlike training algorithms.
 #[derive(Clone, Copy, Debug, Serialize)]

--- a/finalfrontier/src/train_model.rs
+++ b/finalfrontier/src/train_model.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 use toml::Value;
 
 use crate::vec_simd::{l2_normalize, scale, scaled_add};
-use crate::{CommonConfig, Vocab, WriteModelBinary};
+use crate::{CommonConfig, Idx, Vocab, WriteModelBinary};
 
 /// Training model.
 ///
@@ -56,7 +56,7 @@ where
         let distribution = Uniform::new_inclusive(-init_bound, init_bound);
 
         let input = Array2::random(
-            (trainer.n_input_types(), config.dims as usize),
+            (trainer.input_vocab().n_input_types(), config.dims as usize),
             distribution,
         )
         .into();
@@ -101,15 +101,21 @@ impl<T> TrainModel<T> {
     }
 
     /// Get the mean input embedding of the given indices.
-    pub(crate) fn mean_input_embedding(&self, indices: &[u64]) -> Array1<f32> {
-        Self::mean_embedding(self.input.view(), indices)
+    pub(crate) fn mean_input_embedding<I>(&self, idx: &I) -> Array1<f32>
+    where
+        I: Idx,
+    {
+        Self::mean_embedding(self.input.view(), idx)
     }
 
     /// Get the mean input embedding of the given indices.
-    fn mean_embedding(embeds: ArrayView2<f32>, indices: &[u64]) -> Array1<f32> {
+    fn mean_embedding<I>(embeds: ArrayView2<f32>, indices: &I) -> Array1<f32>
+    where
+        I: Idx,
+    {
         let mut embed = Array1::zeros((embeds.cols(),));
 
-        for &idx in indices.iter() {
+        for idx in indices.indices_iter() {
             scaled_add(
                 embed.view_mut(),
                 embeds.index_axis(Axis(0), idx as usize),
@@ -162,6 +168,7 @@ where
     W: Seek + Write,
     T: Trainer<InputVocab = V, Metadata = M>,
     V: Vocab + Into<VocabWrap>,
+    V::VocabType: ToString,
     M: Serialize,
 {
     fn write_model_binary(self, write: &mut W) -> Result<(), Error> {
@@ -171,13 +178,18 @@ where
 
         // Compute and write word embeddings.
         let mut norms = vec![0f32; trainer.input_vocab().len()];
-        for (i, norm) in norms
+        for (i, (norm, word)) in norms
             .iter_mut()
-            .enumerate()
+            .zip(trainer.input_vocab().types())
             .take(trainer.input_vocab().len())
+            .enumerate()
         {
-            let input = trainer.input_indices(i);
+            let input = trainer.input_vocab().idx(word.label()).unwrap();
             let mut embed = Self::mean_embedding(input_matrix.view(), &input);
+            //                match input {
+            //                Idx::Multi(v) => Self::mean_embedding(input_matrix.view(), &v),
+            //                Idx::Single(idx) => input_matrix.row(idx).to_owned(),
+            //            };
             *norm = l2_normalize(embed.view_mut());
             input_matrix.index_axis_mut(Axis(0), i).assign(&embed);
         }
@@ -194,9 +206,6 @@ where
 pub trait Trainer {
     type InputVocab: Vocab;
     type Metadata;
-
-    /// Given an input index get all associated indices.
-    fn input_indices(&self, idx: usize) -> Vec<u64>;
 
     /// Get the trainer's input vocabulary.
     fn input_vocab(&self) -> &Self::InputVocab;
@@ -226,12 +235,13 @@ pub trait Trainer {
 /// TrainIterFrom.
 ///
 /// This trait defines how some input `&S` is transformed into an iterator of training examples.
-pub trait TrainIterFrom<S>
+pub trait TrainIterFrom<S, I>
 where
     S: ?Sized,
+    I: Idx,
 {
-    type Iter: Iterator<Item = (usize, Self::Contexts)>;
-    type Contexts: Sized + IntoIterator<Item = usize>;
+    type Iter: Iterator<Item = (I, Self::Contexts)>;
+    type Contexts: IntoIterator<Item = usize>;
 
     fn train_iter_from(&mut self, sequence: &S) -> Self::Iter;
 }
@@ -360,7 +370,7 @@ mod tests {
 
         // Mean input embedding.
         assert!(all_close(
-            model.mean_input_embedding(&[0, 1]).as_slice().unwrap(),
+            model.mean_input_embedding(&vec![0, 1]).as_slice().unwrap(),
             &[2.5, 3.5, 4.5],
             1e-5
         ));


### PR DESCRIPTION
First commit to allow training without subwords. Adds the Idx trait and an associated type Idx to vocab. The trait abstracts over the different index types of the different vocabs.

This implementation also has some edges that we might want to smooth out. Since it doesn't use an enum but a trait and associated types, we shouldn't have much of a memory overhead. 

A downside of this approach is in the `SkipGramIter` impl, we can't swap with a cheap enum variant. Since the `ids` vector now is a collection of `Vec<u64>`, we need to swap with a `Vec<u64>` containing a single index in order to avoid cloning the full vec. The only other way I'd see is storing a collection of `Box<Idx>` in the iter, but then we add an indirection to all indices.