### PR TITLE
Change Vocab and Trainers to prepare non-subword training. [Traits, take2]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/finalfrontier-utils/Cargo.toml
+++ b/finalfrontier-utils/Cargo.toml
@@ -20,3 +20,4 @@ num_cpus = "1"
 rand = "0.6"
 rand_xorshift = "0.1"
 stdinout = "0.4"
+serde = { version = "1", features = ["derive"] }

--- a/finalfrontier-utils/src/bin/ff-train-skipgram.rs
+++ b/finalfrontier-utils/src/bin/ff-train-skipgram.rs
@@ -11,6 +11,7 @@ use finalfrontier::{
 use finalfrontier_utils::{show_progress, thread_data_text, FileProgress, SkipGramApp};
 use rand::{FromEntropy, Rng};
 use rand_xorshift::XorShiftRng;
+use serde::Serialize;
 use stdinout::OrExit;
 
 const PROGRESS_UPDATE_INTERVAL: u64 = 200;
@@ -65,9 +66,9 @@ fn main() {
         .or_exit("Cannot write model", 1);
 }
 
-fn do_work<P, R>(
+fn do_work<P, R, V>(
     corpus_path: P,
-    mut sgd: SGD<SkipgramTrainer<R>>,
+    mut sgd: SGD<SkipgramTrainer<R, V>>,
     thread: usize,
     n_threads: usize,
     epochs: u32,
@@ -75,6 +76,9 @@ fn do_work<P, R>(
 ) where
     P: Into<PathBuf>,
     R: Clone + Rng,
+    V: Vocab<VocabType = String>,
+    V::Config: Serialize,
+    for<'a> &'a V::IdxType: IntoIterator<Item = u64>,
 {
     let n_tokens = sgd.model().input_vocab().n_types();
 

--- a/finalfrontier/src/dep_trainer.rs
+++ b/finalfrontier/src/dep_trainer.rs
@@ -5,6 +5,7 @@ use failure::{err_msg, Error};
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
 
+use crate::idx::{WordIdx, WordWithSubwordsIdx};
 use crate::sampling::ZipfRangeGenerator;
 use crate::train_model::{NegativeSamples, TrainIterFrom};
 use crate::util::ReseedOnCloneRng;
@@ -81,15 +82,18 @@ impl<R> TrainIterFrom<Sentence> for DepembedsTrainer<R>
 where
     R: Rng,
 {
-    type Iter = Box<Iterator<Item = (usize, Vec<usize>)>>;
+    type Iter = Box<Iterator<Item = (Self::Focus, Vec<usize>)>>;
+    type Focus = WordWithSubwordsIdx;
     type Contexts = Vec<usize>;
 
     fn train_iter_from(&mut self, sentence: &Sentence) -> Self::Iter {
-        let invalid_idx = self.input_vocab.len();
-        let mut tokens = vec![invalid_idx; sentence.len() - 1];
+        let invalid_idx = self.input_vocab.len() as u64;
+        let mut tokens = vec![WordIdx::from_word_idx(invalid_idx); sentence.len() - 1];
         for (idx, token) in sentence.iter().filter_map(|node| node.token()).enumerate() {
             if let Some(vocab_idx) = self.input_vocab.idx(token.form()) {
-                if self.rng.gen_range(0f32, 1f32) < self.input_vocab.discard(vocab_idx) {
+                if self.rng.gen_range(0f32, 1f32)
+                    < self.input_vocab.discard(vocab_idx.word_idx() as usize)
+                {
                     tokens[idx] = vocab_idx
                 }
             }
@@ -98,11 +102,13 @@ where
         let mut contexts = vec![Vec::new(); sentence.len() - 1];
         let graph = sentence.dep_graph();
         for (focus, dep) in DependencyIterator::new_from_config(&graph, self.dep_config)
-            .filter(|(focus, _dep)| tokens[*focus] != invalid_idx)
+            .filter(|(focus, _dep)| tokens[*focus].word_idx() != invalid_idx)
         {
             if let Some(dep_id) = self.output_vocab.idx(&dep) {
-                if self.rng.gen_range(0f32, 1f32) < self.output_vocab.discard(dep_id) {
-                    contexts[focus].push(dep_id)
+                if self.rng.gen_range(0f32, 1f32)
+                    < self.output_vocab.discard(dep_id.word_idx() as usize)
+                {
+                    contexts[focus].push(dep_id.word_idx() as usize)
                 }
             }
         }
@@ -110,7 +116,7 @@ where
             tokens
                 .into_iter()
                 .zip(contexts.into_iter())
-                .filter(move |(focus, _)| *focus != invalid_idx),
+                .filter(move |(focus, _)| focus.word_idx() != invalid_idx),
         )
     }
 }
@@ -121,12 +127,6 @@ where
 {
     type InputVocab = SubwordVocab;
     type Metadata = DepembedsMetadata<SubwordVocabConfig, SimpleVocabConfig>;
-
-    fn input_indices(&self, idx: usize) -> Vec<u64> {
-        let mut v = self.input_vocab.subword_indices_idx(idx).unwrap().to_vec();
-        v.push(idx as u64);
-        v
-    }
 
     fn input_vocab(&self) -> &SubwordVocab {
         &self.input_vocab

--- a/finalfrontier/src/idx.rs
+++ b/finalfrontier/src/idx.rs
@@ -1,0 +1,131 @@
+use std::iter::FusedIterator;
+use std::{option, slice};
+
+/// A single lookup index.
+#[derive(Copy, Clone)]
+pub struct SingleIdx {
+    word_idx: u64,
+}
+
+/// A lookup index with associated subword indices.
+#[derive(Clone)]
+pub struct WordWithSubwordsIdx {
+    word_idx: u64,
+    subwords: Vec<u64>,
+}
+
+impl WordWithSubwordsIdx {
+    pub(crate) fn new(word_idx: u64, subwords: impl Into<Vec<u64>>) -> Self {
+        WordWithSubwordsIdx {
+            word_idx,
+            subwords: subwords.into(),
+        }
+    }
+}
+
+/// Vocabulary indexing trait.
+///
+/// This trait defines methods shared by indexing types.
+pub trait WordIdx: Clone {
+    /// Return the unique word index for the WordIdx.
+    fn word_idx(&self) -> u64;
+
+    /// Build a new WordIdx containing only a single index.
+    fn from_word_idx(word_idx: u64) -> Self;
+
+    /// Return the number of indices.
+    fn len(&self) -> usize;
+}
+
+impl WordIdx for SingleIdx {
+    fn word_idx(&self) -> u64 {
+        self.word_idx
+    }
+
+    fn from_word_idx(word_idx: u64) -> Self {
+        SingleIdx { word_idx }
+    }
+
+    fn len(&self) -> usize {
+        1
+    }
+}
+
+impl<'a> IntoIterator for &'a SingleIdx {
+    type Item = u64;
+    type IntoIter = option::IntoIter<u64>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Some(self.word_idx).into_iter()
+    }
+}
+
+impl WordIdx for WordWithSubwordsIdx {
+    fn word_idx(&self) -> u64 {
+        self.word_idx
+    }
+
+    fn from_word_idx(word_idx: u64) -> Self {
+        WordWithSubwordsIdx {
+            word_idx,
+            subwords: Vec::new(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        1 + self.subwords.len()
+    }
+}
+
+impl<'a> IntoIterator for &'a WordWithSubwordsIdx {
+    type Item = u64;
+    type IntoIter = IdxIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IdxIter {
+            word_idx: Some(self.word_idx),
+            subwords: self.subwords.iter(),
+        }
+    }
+}
+
+/// Iterator over Indices.
+pub struct IdxIter<'a> {
+    word_idx: Option<u64>,
+    subwords: slice::Iter<'a, u64>,
+}
+
+impl<'a> Iterator for IdxIter<'a> {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(idx) = self.subwords.next() {
+            Some(*idx)
+        } else {
+            self.word_idx.take()
+        }
+    }
+}
+
+impl<'a> FusedIterator for IdxIter<'a> {}
+
+#[cfg(test)]
+mod test {
+    use crate::idx::{SingleIdx, WordIdx, WordWithSubwordsIdx};
+
+    #[test]
+    fn test_idx_iter() {
+        let with_subwords = WordWithSubwordsIdx::new(0, vec![24, 4, 42]);
+        let mut idx_iter = (&with_subwords).into_iter();
+        assert_eq!(24, idx_iter.next().unwrap());
+        assert_eq!(4, idx_iter.next().unwrap());
+        assert_eq!(42, idx_iter.next().unwrap());
+        assert_eq!(0, idx_iter.next().unwrap());
+        assert_eq!(0, with_subwords.word_idx());
+
+        let single = SingleIdx::from_word_idx(0);
+        let mut idx_iter = (&single).into_iter();
+        assert_eq!(0, idx_iter.next().unwrap());
+        assert_eq!(0, single.word_idx());
+    }
+}

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -10,6 +10,8 @@ pub use crate::deps::{DepIter, Dependency, DependencyIterator};
 pub(crate) mod dep_trainer;
 pub use crate::dep_trainer::DepembedsTrainer;
 
+pub(crate) mod idx;
+
 mod io;
 pub use crate::io::{SentenceIterator, WriteModelBinary, WriteModelText, WriteModelWord2Vec};
 


### PR DESCRIPTION
Yet another approach. This time based on two traits that the index types implement. The main ideas behind this iteration are:
* `SGD` and  `TrainModel` should be agnostic to the index type they receive.
* indexing should be resolved inside `Vocab` and `Trainer`. 
* `SGD` only needs an iterator over the indices, `TrainModel` additionally requires `.len()`. 

The relevant traits are:
* `IndexIterator`, providing `.iter()` over the indices and `.len()`, implemented on references of the index types.
* `WordIdx`, providing `.word_idx()` to get the word idx and `.from_word_idx()` to construct a variant with only a single index.

Integration of the new traits:
* `TrainModel`'s input lookup methods now take `impl IndexIterator` as argument.
*  `TrainIterFrom` has an associated `Focus` type, `update_sentence` places bounds for `&TrainIterFrom::Focus: IndexIterator`
* `NegativeSamplingSGD` now takes `impl IntoIterator<Item=u64>` as argument for inputs.

The indexing types and traits reside in their own `idx` module, since `vocab` started to get quite crowded.