### PR TITLE
Make input vocabulary of depembeds trainer generic.

### DIFF
--- a/finalfrontier-utils/src/bin/ff-train-deps.rs
+++ b/finalfrontier-utils/src/bin/ff-train-deps.rs
@@ -15,6 +15,7 @@ use finalfrontier::{
 use finalfrontier_utils::{show_progress, thread_data_conllx, DepembedsApp, FileProgress};
 use rand::{FromEntropy, Rng};
 use rand_xorshift::XorShiftRng;
+use serde::Serialize;
 use stdinout::OrExit;
 
 const PROGRESS_UPDATE_INTERVAL: u64 = 200;
@@ -78,9 +79,9 @@ fn main() {
         .or_exit("Cannot write model", 1);
 }
 
-fn do_work<P, R>(
+fn do_work<P, R, V>(
     corpus_path: P,
-    mut sgd: SGD<DepembedsTrainer<R>>,
+    mut sgd: SGD<DepembedsTrainer<R, V>>,
     thread: usize,
     n_threads: usize,
     epochs: u32,
@@ -89,6 +90,9 @@ fn do_work<P, R>(
 ) where
     P: Into<PathBuf>,
     R: Clone + Rng,
+    V: Vocab<VocabType = String>,
+    V::Config: Serialize,
+    for<'a> &'a V::IdxType: IntoIterator<Item = u64>,
 {
     let n_tokens = sgd.model().input_vocab().n_types();
 

--- a/finalfrontier/src/idx.rs
+++ b/finalfrontier/src/idx.rs
@@ -4,7 +4,17 @@ use std::{option, slice};
 /// A single lookup index.
 #[derive(Copy, Clone)]
 pub struct SingleIdx {
-    word_idx: u64,
+    idx: u64,
+}
+
+impl SingleIdx {
+    pub(crate) fn new(idx: u64) -> Self {
+        SingleIdx { idx }
+    }
+
+    pub(crate) fn idx(self) -> u64 {
+        self.idx
+    }
 }
 
 /// A lookup index with associated subword indices.
@@ -39,11 +49,11 @@ pub trait WordIdx: Clone {
 
 impl WordIdx for SingleIdx {
     fn word_idx(&self) -> u64 {
-        self.word_idx
+        self.idx
     }
 
     fn from_word_idx(word_idx: u64) -> Self {
-        SingleIdx { word_idx }
+        SingleIdx::new(word_idx)
     }
 
     fn len(&self) -> usize {
@@ -56,7 +66,7 @@ impl<'a> IntoIterator for &'a SingleIdx {
     type IntoIter = option::IntoIter<u64>;
 
     fn into_iter(self) -> Self::IntoIter {
-        Some(self.word_idx).into_iter()
+        Some(self.idx).into_iter()
     }
 }
 

--- a/finalfrontier/src/sgd.rs
+++ b/finalfrontier/src/sgd.rs
@@ -61,10 +61,10 @@ where
     ///
     /// This applies a gradient descent step on the sentence, with the given
     /// learning rate.
-    pub fn update_sentence<S>(&mut self, sentence: &S, lr: f32)
+    pub fn update_sentence<'b, S>(&mut self, sentence: &S, lr: f32)
     where
         S: ?Sized,
-        T: TrainIterFrom<S> + Trainer + NegativeSamples,
+        T: TrainIterFrom<'b, S> + Trainer + NegativeSamples,
         for<'a> &'a T::Focus: IntoIterator<Item = u64>,
         T::Focus: WordIdx,
     {

--- a/finalfrontier/src/skipgram_trainer.rs
+++ b/finalfrontier/src/skipgram_trainer.rs
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl<S, R, V, I> TrainIterFrom<[S]> for SkipgramTrainer<R, V>
+impl<'a, S, R, V, I> TrainIterFrom<'a, [S]> for SkipgramTrainer<R, V>
 where
     S: Hash + Eq,
     R: Rng + Clone,

--- a/finalfrontier/src/train_model.rs
+++ b/finalfrontier/src/train_model.rs
@@ -242,7 +242,7 @@ pub trait Trainer {
 /// TrainIterFrom.
 ///
 /// This trait defines how some input `&S` is transformed into an iterator of training examples.
-pub trait TrainIterFrom<S>
+pub trait TrainIterFrom<'a, S>
 where
     S: ?Sized,
 {


### PR DESCRIPTION
Generifies the input vocabulary of the depembeds trainer. This requires the addition of a lifetime parameter to the TrainIterFrom trait. Else we can't express the required lifetime for the associated `Focus` type since `Box<T>` assumes `T: 'static`. 