### PR TITLE
Lower width of progress bars.

### DIFF
--- a/finalfrontier-utils/src/progress.rs
+++ b/finalfrontier-utils/src/progress.rs
@@ -18,7 +18,7 @@ impl FileProgress {
         let progress = ProgressBar::new(metadata.len());
         progress.set_style(
             ProgressStyle::default_bar()
-                .template("{bar:40} {bytes}/{total_bytes} ETA: {eta_precise}"),
+                .template("{bar:30} {bytes}/{total_bytes} ETA: {eta_precise}"),
         );
 
         Ok(FileProgress {

--- a/finalfrontier-utils/src/util.rs
+++ b/finalfrontier-utils/src/util.rs
@@ -499,7 +499,7 @@ where
 
     let pb = ProgressBar::new(u64::from(config.epochs) * n_tokens as u64);
     pb.set_style(
-        ProgressStyle::default_bar().template("{bar:40} {percent}% {msg} ETA: {eta_precise}"),
+        ProgressStyle::default_bar().template("{bar:30} {percent}% {msg} ETA: {eta_precise}"),
     );
 
     while sgd.n_tokens_processed() < n_tokens * config.epochs as usize {


### PR DESCRIPTION
Get width of progress report below 80 columns.

Stops standard-width terminal windows from being spammed.