### PR TITLE
Mark trait objects with dyn

### DIFF
--- a/finalfrontier/src/dep_trainer.rs
+++ b/finalfrontier/src/dep_trainer.rs
@@ -86,7 +86,7 @@ where
     V::VocabType: Borrow<str>,
     V::IdxType: WordIdx + 'a,
 {
-    type Iter = Box<Iterator<Item = (Self::Focus, Vec<usize>)> + 'a>;
+    type Iter = Box<dyn Iterator<Item = (Self::Focus, Vec<usize>)> + 'a>;
     type Focus = V::IdxType;
     type Contexts = Vec<usize>;
 

--- a/finalfrontier/src/deps.rs
+++ b/finalfrontier/src/deps.rs
@@ -122,7 +122,7 @@ impl<'a> DependencyIterator<'a> {
     pub fn new_from_config(
         graph: &'a DepGraph<'a>,
         config: DepembedsConfig,
-    ) -> Box<Iterator<Item = (usize, Dependency)> + 'a> {
+    ) -> Box<dyn Iterator<Item = (usize, Dependency)> + 'a> {
         let iter = DependencyIterator::new(graph, config.depth as usize);
 
         match (config.normalize, config.untyped, config.use_root) {


### PR DESCRIPTION
Rust 1.37.0 gives warnings for bare trait objects.