### PR TITLE
Add NGram vocab config.

### DIFF
--- a/finalfrontier/src/config.rs
+++ b/finalfrontier/src/config.rs
@@ -97,6 +97,37 @@ pub struct DepembedsConfig {
     pub untyped: bool,
 }
 
+/// Hyperparameters for NGram vocabs.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename = "NGramVocab")]
+#[serde(tag = "type")]
+pub struct NGramVocabConfig {
+    /// Minimum n-gram length for subword units (inclusive).
+    pub min_n: u32,
+
+    /// Maximum n-gram length for subword units (inclusive).
+    pub max_n: u32,
+
+    /// Minimum token count.
+    ///
+    /// No word-specific embeddings will be trained for tokens occurring less
+    /// than this count.
+    pub min_token_count: u32,
+
+    /// Minimum NGram count.
+    ///
+    /// Ngrams occurring less than `min_count` times in in-vocabulary tokens
+    /// will be ignored.
+    pub min_ngram_count: u32,
+
+    /// Discard threshold.
+    ///
+    /// The discard threshold is used to compute the discard probability of
+    /// a token. E.g. with a threshold of 0.00001 tokens with approximately
+    /// that probability will never be discarded.
+    pub discard_threshold: f32,
+}
+
 /// Hyperparameters for subword-vocabs.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename = "SubwordVocab")]

--- a/finalfrontier/src/vocab/mod.rs
+++ b/finalfrontier/src/vocab/mod.rs
@@ -1,4 +1,3 @@
-// pub (crate) mod ngram;
 pub(crate) mod simple;
 pub(crate) mod subword;
 


### PR DESCRIPTION
Add NGram vocab config.

Pretty straight forward, too. This PR introduces a struct holding the hyperparameters for models with explciitly stored ngrams.

Should probably wait for #62 to be merged (or drop the 1st commit if we don't want to restructure)