### PR TITLE
Generify subword vocab configs.

### DIFF
--- a/finalfrontier-utils/src/bin/ff-train-deps.rs
+++ b/finalfrontier-utils/src/bin/ff-train-deps.rs
@@ -35,7 +35,7 @@ fn main() {
             train(input_vocab, output_vocab, app);
         }
         VocabConfig::SubwordVocab(config) => {
-            let (input_vocab, output_vocab) = build_vocab::<_, SubwordVocab<_>, _>(
+            let (input_vocab, output_vocab) = build_vocab::<_, SubwordVocab<_, _>, _>(
                 config,
                 app.output_vocab_config(),
                 app.depembeds_config(),

--- a/finalfrontier-utils/src/bin/ff-train-skipgram.rs
+++ b/finalfrontier-utils/src/bin/ff-train-skipgram.rs
@@ -23,7 +23,7 @@ fn main() {
     let app = SkipGramApp::new();
     match app.vocab_config() {
         VocabConfig::SubwordVocab(config) => {
-            let vocab: SubwordVocab<_> = build_vocab(config, app.corpus());
+            let vocab: SubwordVocab<_, _> = build_vocab(config, app.corpus());
             train(vocab, app);
         }
         VocabConfig::SimpleVocab(config) => {

--- a/finalfrontier-utils/src/util.rs
+++ b/finalfrontier-utils/src/util.rs
@@ -6,8 +6,8 @@ use indicatif::{ProgressBar, ProgressStyle};
 use stdinout::OrExit;
 
 use finalfrontier::{
-    CommonConfig, DepembedsConfig, LossType, ModelType, SimpleVocabConfig, SkipGramConfig,
-    SubwordVocabConfig, Trainer, Vocab, SGD,
+    BucketConfig, CommonConfig, DepembedsConfig, LossType, ModelType, SimpleVocabConfig,
+    SkipGramConfig, SubwordVocabConfig, Trainer, Vocab, SGD,
 };
 
 static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
@@ -448,7 +448,7 @@ fn common_config_from_matches(matches: &ArgMatches) -> CommonConfig {
 
 #[derive(Copy, Clone)]
 pub enum VocabConfig {
-    SubwordVocab(SubwordVocabConfig),
+    SubwordVocab(SubwordVocabConfig<BucketConfig>),
     SimpleVocab(SimpleVocabConfig),
 }
 
@@ -481,11 +481,11 @@ fn vocab_config_from_matches(matches: &ArgMatches) -> VocabConfig {
             .map(|v| v.parse().or_exit("Cannot parse maximum n-gram length", 1))
             .unwrap();
         VocabConfig::SubwordVocab(SubwordVocabConfig {
-            min_n,
-            max_n,
-            buckets_exp,
-            min_count,
             discard_threshold,
+            min_count,
+            max_n,
+            min_n,
+            indexer: BucketConfig { buckets_exp },
         })
     }
 }

--- a/finalfrontier/src/config.rs
+++ b/finalfrontier/src/config.rs
@@ -97,54 +97,11 @@ pub struct DepembedsConfig {
     pub untyped: bool,
 }
 
-/// Hyperparameters for NGram vocabs.
-#[derive(Clone, Copy, Debug, Serialize)]
-#[serde(rename = "NGramVocab")]
-#[serde(tag = "type")]
-pub struct NGramVocabConfig {
-    /// Minimum n-gram length for subword units (inclusive).
-    pub min_n: u32,
-
-    /// Maximum n-gram length for subword units (inclusive).
-    pub max_n: u32,
-
-    /// Minimum token count.
-    ///
-    /// No word-specific embeddings will be trained for tokens occurring less
-    /// than this count.
-    pub min_token_count: u32,
-
-    /// Minimum NGram count.
-    ///
-    /// Ngrams occurring less than `min_count` times in in-vocabulary tokens
-    /// will be ignored.
-    pub min_ngram_count: u32,
-
-    /// Discard threshold.
-    ///
-    /// The discard threshold is used to compute the discard probability of
-    /// a token. E.g. with a threshold of 0.00001 tokens with approximately
-    /// that probability will never be discarded.
-    pub discard_threshold: f32,
-}
-
-/// Hyperparameters for subword-vocabs.
+/// Hyperparameters for Subword vocabs.
 #[derive(Clone, Copy, Debug, Serialize)]
 #[serde(rename = "SubwordVocab")]
 #[serde(tag = "type")]
-pub struct SubwordVocabConfig {
-    /// Minimum n-gram length for subword units (inclusive).
-    pub min_n: u32,
-
-    /// Maximum n-gram length for subword units (inclusive).
-    pub max_n: u32,
-
-    /// Bucket exponent. The model will use 2^bucket_exp buckets.
-    ///
-    /// A typical value for this parameter is 21, which gives roughly 2M
-    /// buckets.
-    pub buckets_exp: u32,
-
+pub struct SubwordVocabConfig<V> {
     /// Minimum token count.
     ///
     /// No word-specific embeddings will be trained for tokens occurring less
@@ -157,6 +114,39 @@ pub struct SubwordVocabConfig {
     /// a token. E.g. with a threshold of 0.00001 tokens with approximately
     /// that probability will never be discarded.
     pub discard_threshold: f32,
+
+    /// Minimum n-gram length for subword units (inclusive).
+    pub min_n: u32,
+
+    /// Maximum n-gram length for subword units (inclusive).
+    pub max_n: u32,
+
+    /// Indexer specific parameters.
+    pub indexer: V,
+}
+
+/// Hyperparameters for bucket-vocabs.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename = "Buckets")]
+#[serde(tag = "type")]
+pub struct BucketConfig {
+    /// Bucket exponent. The model will use 2^bucket_exp buckets.
+    ///
+    /// A typical value for this parameter is 21, which gives roughly 2M
+    /// buckets.
+    pub buckets_exp: u32,
+}
+
+/// Hyperparameters for ngram-vocabs.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename = "NGrams")]
+#[serde(tag = "type")]
+pub struct NGramConfig {
+    /// Minimum NGram count.
+    ///
+    /// Ngrams occurring less than `min_count` times in in-vocabulary tokens
+    /// will be ignored.
+    pub min_ngram_count: u32,
 }
 
 /// Hyperparameters for simple vocabs.

--- a/finalfrontier/src/lib.rs
+++ b/finalfrontier/src/lib.rs
@@ -1,7 +1,7 @@
 mod config;
 pub use crate::config::{
-    CommonConfig, DepembedsConfig, LossType, ModelType, SimpleVocabConfig, SkipGramConfig,
-    SubwordVocabConfig,
+    BucketConfig, CommonConfig, DepembedsConfig, LossType, ModelType, NGramConfig,
+    SimpleVocabConfig, SkipGramConfig, SubwordVocabConfig,
 };
 
 mod deps;

--- a/finalfrontier/src/train_model.rs
+++ b/finalfrontier/src/train_model.rs
@@ -262,17 +262,18 @@ pub trait NegativeSamples {
 
 #[cfg(test)]
 mod tests {
+    use finalfusion::subword::FinalfusionHashIndexer;
     use ndarray::Array2;
     use rand::FromEntropy;
     use rand_xorshift::XorShiftRng;
 
     use super::TrainModel;
+    use crate::config::SubwordVocabConfig;
     use crate::idx::WordWithSubwordsIdx;
     use crate::skipgram_trainer::SkipgramTrainer;
     use crate::util::all_close;
     use crate::{
-        CommonConfig, LossType, ModelType, SkipGramConfig, SubwordVocab, SubwordVocabConfig,
-        VocabBuilder,
+        BucketConfig, CommonConfig, LossType, ModelType, SkipGramConfig, SubwordVocab, VocabBuilder,
     };
 
     const TEST_COMMON_CONFIG: CommonConfig = CommonConfig {
@@ -289,12 +290,12 @@ mod tests {
         model: ModelType::SkipGram,
     };
 
-    const VOCAB_CONF: SubwordVocabConfig = SubwordVocabConfig {
-        buckets_exp: 21,
+    const VOCAB_CONF: SubwordVocabConfig<BucketConfig> = SubwordVocabConfig {
         discard_threshold: 1e-4,
         min_count: 2,
         max_n: 6,
         min_n: 3,
+        indexer: BucketConfig { buckets_exp: 21 },
     };
 
     #[test]
@@ -305,9 +306,9 @@ mod tests {
         let common_config = TEST_COMMON_CONFIG.clone();
         let skipgram_config = TEST_SKIP_CONFIG.clone();
         // We just need some bogus vocabulary
-        let mut builder: VocabBuilder<SubwordVocabConfig, String> = VocabBuilder::new(vocab_config);
+        let mut builder: VocabBuilder<_, String> = VocabBuilder::new(vocab_config);
         builder.count("bla".to_string());
-        let vocab: SubwordVocab<_> = builder.into();
+        let vocab: SubwordVocab<_, FinalfusionHashIndexer> = builder.into();
 
         let input = Array2::from_shape_vec((2, 3), vec![1., 2., 3., 4., 5., 6.])
             .unwrap()


### PR DESCRIPTION
Factor out some common parameters.

The motivation is that we need some kind of abstraction over the config in the `SubwordVocab`. We could do this through some trait that `Config` types implement, exposing the common parameters or through a struct with a generic field. The trait version looked much hackier, so I went with the generic struct proposed in this PR.

Theoretically we could factor out `discard_threshold` and `min_count` and make a generic `VocabConfig` including one for `SimpleVocab`. I didn't go for this because we'd get pretty deeply nested types with `VocabConfig<SubwordVocabConfig<BucketConfig>>>` and since `SimpleVocab` is a distinct type, we don't need the abstraction either.