### PR TITLE
Extend Metadata with TrainInfo.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,17 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +239,7 @@ name = "finalfrontier"
 version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conllx 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -497,6 +509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "num-complex"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -988,6 +1009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1127,7 @@ dependencies = [
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -1139,6 +1171,7 @@ dependencies = [
 "checksum ndarray-rand 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a2b87ee9e6a97ea5447ba56903acc5afea3222b0939a2461b0e91e07e54250"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-complex 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb0cf31fb3ff77e6d2a6ebd6800df7fdcd106f2ad89113c9130bcd07f93dffc"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"
@@ -1197,6 +1230,7 @@ dependencies = [
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/finalfusion/finalfrontier.git"
 license = "BlueOak-1.0.0"
 
 [dependencies]
+chrono = "0.4"
 clap = "2"
 cfg-if = "0.1"
 conllx = "0.11"

--- a/src/bin/ff-train-deps.rs
+++ b/src/bin/ff-train-deps.rs
@@ -107,7 +107,7 @@ where
     }
 
     sgd.into_model()
-        .write_model_binary(&mut output_writer)
+        .write_model_binary(&mut output_writer, app.train_info().clone())
         .or_exit("Cannot write model", 1);
 }
 

--- a/src/bin/ff-train-skipgram.rs
+++ b/src/bin/ff-train-skipgram.rs
@@ -85,7 +85,7 @@ where
     }
 
     sgd.into_model()
-        .write_model_binary(&mut output_writer)
+        .write_model_binary(&mut output_writer, app.train_info().clone())
         .or_exit("Cannot write model", 1);
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,6 +5,7 @@ use failure::{Error, ResultExt};
 use indicatif::{ProgressBar, ProgressStyle};
 use memmap::{Mmap, MmapOptions};
 
+use crate::app::TrainInfo;
 use crate::util::EOS;
 
 pub struct FileProgress {
@@ -173,7 +174,7 @@ pub trait WriteModelBinary<W>
 where
     W: Write,
 {
-    fn write_model_binary(self, write: &mut W) -> Result<(), Error>;
+    fn write_model_binary(self, write: &mut W, train_info: TrainInfo) -> Result<(), Error>;
 }
 
 fn whitespace_tokenize(line: &str) -> Vec<String> {


### PR DESCRIPTION
Adds TrainInfo holding information about corpus, number of
threads, timestamps and output file.

Adds a section like this to `metadata`:
~~~
[training_info]
corpus = 'tdz-text.conll'
end_datetime = '2019-10-14 12:11:09'
n_threads = 14
output = 'throwaway'
start_datetime = '2019-10-14 12:10:57'
~~~

I'm not too sure about this particular change:

~~~Rust
fn write_model_binary(self, write: &mut W, train_info: TrainInfo) -> Result<(), Error>; 
~~~

This makes assumptions about every model being trained with a `corpus` field, `n_threads` and `output`. We could replace this with `&dyn Serialize`. What do you prefer?