### PR TITLE
Run cargo {fmt,clippy} on just one target

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -6,7 +6,7 @@ cargo build --target ${TARGET}
 cargo test --target ${TARGET}
 
 # On Rust 1.31.0, we only care about passing tests.
-if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+if [ "$TRAVIS_RUST_VERSION" = "stable" ] && [ "$TARGET" = "x86_64-unknown-linux-gnu" ] ; then
   cargo fmt --all -- --check
   cargo clippy -- -D warnings
 fi


### PR DESCRIPTION
It is useless running these on each target, so only run on
x86_64-unknown-linux-gnu.