### PR TITLE
Add finalfrontier(1) man page

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -1,4 +1,4 @@
-all: finalfrontier-skipgram.1 finalfrontier-deps.1
+all: finalfrontier.1 finalfrontier-skipgram.1 finalfrontier-deps.1
 
 clean:
 	rm -f *.1 *.5

--- a/man/finalfrontier-deps.1.md
+++ b/man/finalfrontier-deps.1.md
@@ -137,4 +137,4 @@ model from contexts with depth up to 2:
 SEE ALSO
 ========
 
-`finalfrontier-skipgram`(1)
+`finalfrontier`(1), `finalfrontier-skipgram`(1)

--- a/man/finalfrontier-skipgram.1.md
+++ b/man/finalfrontier-skipgram.1.md
@@ -124,4 +124,4 @@ structured skip-gram model with a context window of 5 tokens:
 SEE ALSO
 ========
 
-`finalfrontier-deps`(1)
+`finalfrontier`(1), `finalfrontier-deps`(1)

--- a/man/finalfrontier.1.md
+++ b/man/finalfrontier.1.md
@@ -1,0 +1,36 @@
+% FINALFRONTIER(1)
+% Daniel de Kok
+% Nov 1, 2019
+
+NAME
+====
+
+**finalfrontier** -- train finalfusion word embeddings
+
+SYNOPSIS
+========
+
+**finalfrontier** *command* [*options*] [*args*]  
+**finalfrontier** completions *shell*  
+**finalfrontier** help *command*
+
+DESCRIPTION
+===========
+
+finalfrontier is a utility for training finalfusion word embeddings.
+
+COMMANDS
+========
+
+`finalfrontier-deps`(1)
+
+:   Train word embeddings using the dependency model (Levy & Goldberg, 2014)
+
+`finalfrontier-skipgram`(1)
+
+:   Train word embeddings using the skipgram model (Mikolov et al, 2013)
+
+SEE ALSO
+========
+
+`finalfrontier-deps`(1), `finalfrontier-skipgram`(1)


### PR DESCRIPTION
Fixes #88

This is just a landing (man) page in case someone tries `man finalfrontier`. I am not sure if `finalfrontier completions` warrants its own man page. It's more something that a packager would use to generate the completion files (such as in the Nix derivation).