### PR TITLE
Add version info to finalfrontier cmd.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,13 @@ fn main() {
     // Known subapplications.
     let apps = vec![subcommands::DepsApp::app(), subcommands::SkipgramApp::app()];
 
+    let version = if let Some(git_desc) = option_env!("MAYBE_FINALFRONTIER_GIT_DESC") {
+        git_desc
+    } else {
+        env!("CARGO_PKG_VERSION")
+    };
     let cli = App::new("finalfrontier")
+        .version(version)
         .settings(DEFAULT_CLAP_SETTINGS)
         .subcommands(apps)
         .subcommand(


### PR DESCRIPTION
`finalfrontier --version`'s output is not informative, we should also print version info for that!

I tried adding it only on the top-level app but that doesn't project to the other apps.