### PR TITLE
Revamp error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "approx"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,26 +42,6 @@ dependencies = [
 name = "autocfg"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "backtrace"
-version = "0.3.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "bitflags"
@@ -219,34 +204,14 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "failure"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "finalfrontier"
 version = "0.7.0"
 dependencies = [
+ "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conllu 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfusion 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -762,11 +727,6 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,17 +795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -990,11 +939,10 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
-"checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
-"checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
@@ -1013,8 +961,6 @@ dependencies = [
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-"checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
-"checksum failure_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 "checksum finalfusion 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f77ea5d36003194aecf85b36a84569eb31fa5bd194d3209bb8835c3a0d937e84"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1072,7 +1018,6 @@ dependencies = [
 "checksum reductive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8cc7b6b2c28e384c88ae98a815663b1a90b7780445d24d2b9c2160303a61c48c"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
-"checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1083,7 +1028,6 @@ dependencies = [
 "checksum stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29f1026ef7b2ded56453d708809e15f148b7f5b6a51e1ee0237964881ab85680"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-"checksum synstructure 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "575be94ccb86e8da37efb894a87e2b660be299b41d8ef347f9d6d79fbe61b1ba"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "54b3d3d2ff68104100ab257bb6bb0cb26c901abe4bd4ba15961f3bf867924012"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/finalfusion/finalfrontier.git"
 license = "BlueOak-1.0.0"
 
 [dependencies]
+anyhow = "1"
 chrono = "0.4"
 clap = "2"
 cfg-if = "0.1"
 conllu = "0.4.1"
-failure = "0.1"
 finalfusion = "0.11"
 fnv = "1"
 indicatif = "0.11"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use failure::{err_msg, Error};
+use anyhow::{bail, Result};
 use serde::Serialize;
 
 /// Model types.
@@ -15,21 +15,21 @@ pub enum ModelType {
 }
 
 impl ModelType {
-    pub fn try_from(model: u8) -> Result<ModelType, Error> {
+    pub fn try_from(model: u8) -> Result<ModelType> {
         match model {
             0 => Ok(ModelType::SkipGram),
             1 => Ok(ModelType::StructuredSkipGram),
             2 => Ok(ModelType::DirectionalSkipgram),
-            _ => Err(err_msg(format!("Unknown model type: {}", model))),
+            _ => bail!("Unknown model type: {}", model),
         }
     }
 
-    pub fn try_from_str(model: &str) -> Result<ModelType, Error> {
+    pub fn try_from_str(model: &str) -> Result<ModelType> {
         match model {
             "skipgram" => Ok(ModelType::SkipGram),
             "structgram" => Ok(ModelType::StructuredSkipGram),
             "dirgram" => Ok(ModelType::DirectionalSkipgram),
-            _ => Err(err_msg(format!("Unknown model type: {}", model))),
+            _ => bail!("Unknown model type: {}", model),
         }
     }
 }
@@ -42,10 +42,10 @@ pub enum LossType {
 }
 
 impl LossType {
-    pub fn try_from(model: u8) -> Result<LossType, Error> {
+    pub fn try_from(model: u8) -> Result<LossType> {
         match model {
             0 => Ok(LossType::LogisticNegativeSampling),
-            _ => Err(err_msg(format!("Unknown model type: {}", model))),
+            _ => bail!("Unknown model type: {}", model),
         }
     }
 }

--- a/src/dep_trainer.rs
+++ b/src/dep_trainer.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 use std::sync::Arc;
 
+use anyhow::{bail, Result};
 use conllu::graph::Sentence;
-use failure::{err_msg, Error};
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
 
@@ -137,10 +137,10 @@ where
         &self.input_vocab
     }
 
-    fn try_into_input_vocab(self) -> Result<Self::InputVocab, Error> {
+    fn try_into_input_vocab(self) -> Result<Self::InputVocab> {
         match Arc::try_unwrap(self.input_vocab) {
             Ok(vocab) => Ok(vocab),
-            Err(_) => Err(err_msg("Cannot unwrap input vocab.")),
+            Err(_) => bail!("Cannot unwrap input vocab."),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::io::stdout;
 
+use anyhow::Result;
 use clap::{App, AppSettings, Arg, Shell, SubCommand};
 
 mod subcommands;
@@ -11,7 +12,7 @@ static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::SubcommandRequiredElseHelp,
 ];
 
-fn main() {
+fn main() -> Result<()> {
     // Known subapplications.
     let apps = vec![subcommands::DepsApp::app(), subcommands::SkipgramApp::app()];
 
@@ -39,10 +40,11 @@ fn main() {
                 .value_of("shell")
                 .unwrap();
             write_completion_script(cli, shell.parse::<Shell>().unwrap());
+            Ok(())
         }
-        "deps" => subcommands::DepsApp::parse(matches.subcommand_matches("deps").unwrap()).run(),
+        "deps" => subcommands::DepsApp::parse(matches.subcommand_matches("deps").unwrap())?.run(),
         "skipgram" => {
-            subcommands::SkipgramApp::parse(matches.subcommand_matches("skipgram").unwrap()).run()
+            subcommands::SkipgramApp::parse(matches.subcommand_matches("skipgram").unwrap())?.run()
         }
         _unknown => unreachable!(),
     }

--- a/src/skipgram_trainer.rs
+++ b/src/skipgram_trainer.rs
@@ -4,7 +4,7 @@ use std::iter::FusedIterator;
 use std::sync::Arc;
 use std::{cmp, mem};
 
-use failure::{err_msg, Error};
+use anyhow::{bail, Result};
 use rand::{Rng, SeedableRng};
 use serde::Serialize;
 
@@ -119,10 +119,10 @@ where
         &self.vocab
     }
 
-    fn try_into_input_vocab(self) -> Result<V, Error> {
+    fn try_into_input_vocab(self) -> Result<V> {
         match Arc::try_unwrap(self.vocab) {
             Ok(vocab) => Ok(vocab),
-            Err(_) => Err(err_msg("Cannot unwrap input vocab.")),
+            Err(_) => bail!("Cannot unwrap input vocab."),
         }
     }
 


### PR DESCRIPTION
- Replace `failure` dependency by `anyhow`. `anyhow` is more or less
  the successor of `failure` for applications. It uses the standard
  library's `Error` trait rather than the custom `Fail` trait
- Bubble up errors all the way up to `main`. Since `anyhow` actually
  gives us nice error message, the OrExit trait is not needed anymore.