### PR TITLE
Report what SIMD features are used

### DIFF
--- a/src/subcommands/deps.rs
+++ b/src/subcommands/deps.rs
@@ -192,6 +192,9 @@ impl FinalfrontierApp for DepsApp {
     }
 
     fn run(&self) -> Result<()> {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        eprintln!("SIMD features: {}", Self::simd_features().join(" "));
+
         match self.input_vocab_config() {
             VocabConfig::SimpleVocab(config) => {
                 let (input_vocab, output_vocab) = build_vocab::<_, SimpleVocab<String>, _>(

--- a/src/subcommands/skipgram.rs
+++ b/src/subcommands/skipgram.rs
@@ -131,6 +131,9 @@ impl FinalfrontierApp for SkipgramApp {
     }
 
     fn run(&self) -> Result<()> {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        eprintln!("SIMD features: {}", Self::simd_features().join(" "));
+
         match self.vocab_config() {
             VocabConfig::SubwordVocab(config) => match config.indexer.indexer_type {
                 BucketIndexerType::Finalfusion => {

--- a/src/subcommands/traits.rs
+++ b/src/subcommands/traits.rs
@@ -284,4 +284,30 @@ where
             s => unreachable!(format!("Unhandled vocab type: {}", s)),
         }
     }
+
+    /// Get features that will be used by SIMD code paths.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    fn simd_features() -> Vec<&'static str> {
+        let mut features = vec![];
+
+        if is_x86_feature_detected!("sse") {
+            features.push("+sse");
+        } else {
+            features.push("-sse");
+        }
+
+        if is_x86_feature_detected!("avx") {
+            features.push("+avx");
+        } else {
+            features.push("-avx");
+        }
+
+        if is_x86_feature_detected!("fma") {
+            features.push("+fma");
+        } else {
+            features.push("-fma");
+        }
+
+        features
+    }
 }


### PR DESCRIPTION
So that you don't have to read something like `perf` output to figure
out what instruction set is used on a particular machine.