### PR TITLE
Implement target size for vocabularies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "zipf 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -683,6 +684,11 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "superslice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "syn"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +923,7 @@ dependencies = [
 "checksum smallvec 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 "checksum stdinout 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "731d3aab9a724e1509adb463b6c4e320bc4b86c49766c96a321c0d7c3e5efea1"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 "checksum syn 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
 "checksum terminal_size 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
 "checksum termios 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6f0fcee7b24a25675de40d5bb4de6e41b0df07bc9856295e7e2b3a3600c400c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand_core = "0.5"
 rand_xorshift = "0.2"
 serde = { version = "1", features = ["derive"] }
 stdinout = "0.4"
+superslice = "1.0"
 toml = "0.5"
 zipf = "6"
 

--- a/man/finalfrontier-deps.1.md
+++ b/man/finalfrontier-deps.1.md
@@ -42,6 +42,12 @@ discarded during training. The default context discard threshold is *1e-4*.
 occuring fewer than *FREQ* times are not considered during training.  The
 default minimum count is 5.
 
+`--context-target-size` *SIZE*
+
+:   The target size for the context vocabulary. At most *SIZE* contexts are
+    included for training. Only contexts appearing more frequently than the
+    context at *SIZE* are included.
+
 `--dependency-depth` *DEPTH*
 
 :   Dependency contexts up to *DEPTH* distance from the focus word in the
@@ -79,6 +85,12 @@ rate decreases monotonically during training.
 occuring fewer than *FREQ* times are not considered during training. The default
 minimum count is 5.
 
+`--target-size` *SIZE*
+
+:   The target size for the token vocabulary. At most *SIZE* tokens are
+    included for training. Only tokens appearing more frequently than the token
+    at *SIZE* are included.
+
 `--minn` *LEN*
 
 :   The minimum n-gram length for subword representations. Default: 3
@@ -88,6 +100,13 @@ minimum count is 5.
 :   The minimum n-gram frequency. n-grams occurring fewer than *FREQ*
     times are excluded from training. This option is only applicable
     with the *ngrams* argument of the `subwords` option.
+
+`--ngram-target-size` *SIZE*
+
+:   The target size for the n-gram vocabulary. At most *SIZE* n-ngrams are
+    included for training. Only n-grams appearing more frequently than the
+    n-gram at *SIZE* are included. This option is only applicable with the
+    *ngrams* argument of the `subwords` option.
 
 `--normalize-contexts`
 

--- a/man/finalfrontier-skipgram.1.md
+++ b/man/finalfrontier-skipgram.1.md
@@ -69,6 +69,12 @@ OPTIONS
     fewer than *FREQ* times are not considered during training. The
     default minimum count is 5.
 
+`--target-size` *SIZE*
+
+:   The target size for the token vocabulary. At most *SIZE* tokens are
+    included for training. Only tokens appearing more frequently than the token
+    at *SIZE* are included.
+
 `--minn` *LEN*
 
 :   The minimum n-gram length for subword representations. Default: 3
@@ -94,6 +100,13 @@ OPTIONS
 :   The minimum n-gram frequency. n-grams occurring fewer than *FREQ*
     times are excluded from training. This option is only applicable
     with the *ngrams* argument of the `subwords` option.
+
+`--ngram-target-size` *SIZE*
+
+:   The target size for the n-gram vocabulary. At most *SIZE* n-ngrams are
+    included for training. Only n-grams appearing more frequently than the
+    n-gram at *SIZE* are included. This option is only applicable with the
+    *ngrams* argument of the `subwords` option.
 
 `--ns` *FREQ*
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use std::convert::TryFrom;
 use anyhow::{bail, Error, Result};
 use serde::Serialize;
 
+use crate::vocab::Cutoff;
+
 /// Model types.
 #[derive(Copy, Clone, Debug, Serialize)]
 pub enum ModelType {
@@ -125,11 +127,11 @@ pub struct DepembedsConfig {
 #[serde(rename = "SubwordVocab")]
 #[serde(tag = "type")]
 pub struct SubwordVocabConfig<V> {
-    /// Minimum token count.
+    /// Token cutoff.
     ///
-    /// No word-specific embeddings will be trained for tokens occurring less
-    /// than this count.
-    pub min_count: u32,
+    /// No word-specific embeddings will be trained for tokens excluded by the
+    /// cutoff.
+    pub cutoff: Cutoff,
 
     /// Discard threshold.
     ///
@@ -167,11 +169,10 @@ pub struct BucketConfig {
 #[serde(rename = "NGrams")]
 #[serde(tag = "type")]
 pub struct NGramConfig {
-    /// Minimum NGram count.
+    /// NGram cutoff.
     ///
-    /// Ngrams occurring less than `min_count` times in in-vocabulary tokens
-    /// will be ignored.
-    pub min_ngram_count: u32,
+    /// NGrams excluded by the cutoff will be ignored during training.
+    pub cutoff: Cutoff,
 }
 
 /// Hyperparameters for simple vocabs.
@@ -179,11 +180,11 @@ pub struct NGramConfig {
 #[serde(rename = "SimpleVocab")]
 #[serde(tag = "type")]
 pub struct SimpleVocabConfig {
-    /// Minimum token count.
+    /// Token cutoff.
     ///
-    /// No word-specific embeddings will be trained for tokens occurring less
-    /// than this count.
-    pub min_count: u32,
+    /// No word-specific embeddings will be trained for tokens excluded by the
+    /// cutoff.
+    pub cutoff: Cutoff,
 
     /// Discard threshold.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,5 @@ pub(crate) mod vec_simd;
 
 mod vocab;
 pub use crate::vocab::{
-    simple::SimpleVocab, subword::SubwordVocab, CountedType, Vocab, VocabBuilder, Word,
+    simple::SimpleVocab, subword::SubwordVocab, CountedType, Cutoff, Vocab, VocabBuilder, Word,
 };

--- a/src/subcommands/config.rs
+++ b/src/subcommands/config.rs
@@ -1,8 +1,31 @@
-use finalfrontier::{BucketConfig, NGramConfig, SimpleVocabConfig, SubwordVocabConfig};
+use anyhow::{Context, Result};
+use clap::ArgMatches;
+
+use finalfrontier::{BucketConfig, Cutoff, NGramConfig, SimpleVocabConfig, SubwordVocabConfig};
 
 #[derive(Copy, Clone)]
 pub enum VocabConfig {
     SubwordVocab(SubwordVocabConfig<BucketConfig>),
     NGramVocab(SubwordVocabConfig<NGramConfig>),
     SimpleVocab(SimpleVocabConfig),
+}
+
+pub fn cutoff_from_matches(
+    matches: &ArgMatches,
+    mincount: &str,
+    target_size: &str,
+) -> Result<Option<Cutoff>> {
+    match matches
+        .value_of(mincount)
+        .map(|v| v.parse().context("Cannot parse mincount"))
+        .transpose()?
+        .map(Cutoff::MinCount)
+    {
+        None => Ok(matches
+            .value_of(target_size)
+            .map(|v| v.parse().context("Cannot parse target size"))
+            .transpose()?
+            .map(Cutoff::TargetSize)),
+        some => Ok(some),
+    }
 }

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -1,5 +1,5 @@
 mod config;
-pub use self::config::VocabConfig;
+pub use self::config::{cutoff_from_matches, VocabConfig};
 
 mod deps;
 pub use self::deps::DepsApp;

--- a/src/train_model.rs
+++ b/src/train_model.rs
@@ -286,7 +286,8 @@ mod tests {
     use crate::skipgram_trainer::SkipgramTrainer;
     use crate::util::all_close;
     use crate::{
-        BucketConfig, CommonConfig, LossType, ModelType, SkipGramConfig, SubwordVocab, VocabBuilder,
+        BucketConfig, CommonConfig, Cutoff, LossType, ModelType, SkipGramConfig, SubwordVocab,
+        VocabBuilder,
     };
 
     const TEST_COMMON_CONFIG: CommonConfig = CommonConfig {
@@ -305,7 +306,7 @@ mod tests {
 
     const VOCAB_CONF: SubwordVocabConfig<BucketConfig> = SubwordVocabConfig {
         discard_threshold: 1e-4,
-        min_count: 2,
+        cutoff: Cutoff::MinCount(2),
         max_n: 6,
         min_n: 3,
         indexer: BucketConfig {
@@ -317,7 +318,7 @@ mod tests {
     #[test]
     pub fn model_embed_methods() {
         let mut vocab_config = VOCAB_CONF.clone();
-        vocab_config.min_count = 1;
+        vocab_config.cutoff = Cutoff::MinCount(1);
 
         let common_config = TEST_COMMON_CONFIG.clone();
         let skipgram_config = TEST_SKIP_CONFIG.clone();

--- a/src/vocab/simple.rs
+++ b/src/vocab/simple.rs
@@ -112,15 +112,7 @@ where
     S: Hash + Eq + Clone + Ord,
 {
     fn from(builder: VocabBuilder<SimpleVocabConfig, T>) -> Self {
-        let min_count = builder.config.min_count;
-
-        let mut types: Vec<_> = builder
-            .items
-            .into_iter()
-            .filter(|(_, count)| *count >= min_count as usize)
-            .map(|(item, count)| CountedType::new(item.into(), count))
-            .collect();
-        types.sort_unstable_by(|w1, w2| w2.cmp(&w1));
+        let types = builder.config.cutoff.filter(builder.items);
         SimpleVocab::new(builder.config, types, builder.n_items)
     }
 }
@@ -129,11 +121,11 @@ where
 mod tests {
     use super::{SimpleVocab, Vocab, VocabBuilder};
     use crate::idx::WordIdx;
-    use crate::{util, SimpleVocabConfig};
+    use crate::{util, Cutoff, SimpleVocabConfig};
 
     const TEST_SIMPLECONFIG: SimpleVocabConfig = SimpleVocabConfig {
         discard_threshold: 1e-4,
-        min_count: 2,
+        cutoff: Cutoff::MinCount(2),
     };
 
     #[test]


### PR DESCRIPTION
Add options to set a target size for all vocab types. The target
size sets the maximum number of items in vocabularies, it is
guaranteed to contain less items than this number.

------

Supersedes #94 