### PR TITLE
Add --format option to support output to other formats

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use anyhow::{bail, Error, Result};
 use serde::Serialize;
 
+use crate::io::EmbeddingFormat;
 use crate::vocab::Cutoff;
 
 /// Model types.
@@ -94,6 +95,10 @@ pub struct CommonConfig {
 
     /// The number of training epochs.
     pub epochs: u32,
+
+    /// The output format.
+    #[serde(skip)]
+    pub format: EmbeddingFormat,
 
     /// Number of negative samples to use for each context word.
     pub negative_samples: u32,

--- a/src/subcommands/deps.rs
+++ b/src/subcommands/deps.rs
@@ -299,7 +299,11 @@ where
     }
 
     sgd.into_model()
-        .write_model_binary(&mut output_writer, app.train_info().clone())
+        .write_model_binary(
+            &mut output_writer,
+            app.train_info().clone(),
+            app.common_config.format,
+        )
         .context("Cannot write model")
 }
 

--- a/src/subcommands/skipgram.rs
+++ b/src/subcommands/skipgram.rs
@@ -208,7 +208,11 @@ where
     }
 
     sgd.into_model()
-        .write_model_binary(&mut output_writer, app.train_info().clone())
+        .write_model_binary(
+            &mut output_writer,
+            app.train_info().clone(),
+            app.common_config.format,
+        )
         .context("Cannot write model")
 }
 

--- a/src/subcommands/traits.rs
+++ b/src/subcommands/traits.rs
@@ -19,6 +19,7 @@ static BUCKETS: &str = "buckets";
 static DIMS: &str = "dims";
 static DISCARD: &str = "discard";
 static EPOCHS: &str = "epochs";
+static FORMAT: &str = "format";
 static HASH_INDEXER_TYPE: &str = "hash-indexer";
 static LR: &str = "lr";
 static MINCOUNT: &str = "mincount";
@@ -77,6 +78,15 @@ where
                     .help("Discard threshold")
                     .takes_value(true)
                     .default_value("1e-4"),
+            )
+            .arg(
+                Arg::with_name(FORMAT)
+                    .short("f")
+                    .long("format")
+                    .value_name("FORMAT")
+                    .help("Output format")
+                    .takes_value(true)
+                    .default_value("finalfusion"),
             )
             .arg(
                 Arg::with_name(HASH_INDEXER_TYPE)
@@ -207,6 +217,11 @@ where
             .map(|v| v.parse().context("Cannot parse number of epochs"))
             .transpose()?
             .unwrap();
+        let format = matches
+            .value_of(FORMAT)
+            .map(|v| v.try_into().context("Cannot parse output format"))
+            .transpose()?
+            .unwrap();
         let lr = matches
             .value_of(LR)
             .map(|v| v.parse().context("Cannot parse learning rate"))
@@ -227,6 +242,7 @@ where
             loss: LossType::LogisticNegativeSampling,
             dims,
             epochs,
+            format,
             lr,
             negative_samples,
             zipf_exponent,


### PR DESCRIPTION
We can convert embeddings through finalfusion-utils already, but some
people may not be interested in finalfusion embeddings. This makes it
possible for them to output embeddings in word2vec format without
having to install finalfusion-utils as well.

---

Now if we also had fastText write support in `finalfusion-rust`, we would have the universal Swiss army knife for training embeddings ;).