### PR TITLE
Remove stdinout dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,6 @@ dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdinout 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "zipf 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,11 +670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stdinout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,7 +916,6 @@ dependencies = [
 "checksum scopeguard 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
-"checksum stdinout 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "731d3aab9a724e1509adb463b6c4e320bc4b86c49766c96a321c0d7c3e5efea1"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum superslice 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 "checksum syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ rand = "0.7"
 rand_core = "0.5"
 rand_xorshift = "0.2"
 serde = { version = "1", features = ["derive"] }
-stdinout = "0.4"
 superslice = "1.0"
 toml = "0.5"
 zipf = "6"

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use conllu::graph::{DepGraph, DepTriple};
 
 use crate::DepembedsConfig;
@@ -274,11 +272,11 @@ where
                 match tuple.1 {
                     Dependency::Untyped(ref mut form) => {
                         let normalized = form.to_lowercase();
-                        mem::replace(form, normalized);
+                        *form = normalized;
                     }
                     Dependency::Typed { ref mut form, .. } => {
                         let normalized = form.to_lowercase();
-                        mem::replace(form, normalized);
+                        *form = normalized;
                     }
                 }
                 tuple


### PR DESCRIPTION
It is not used anymore since we revamped error handling.