### PR TITLE
Add dot product benchmarks, improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,10 +48,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bstr"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "cast"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "cc"
@@ -67,6 +94,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -102,7 +135,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6028c5904fccbda78f6ed6c50630ff5c8b58f58dc9df8ecab380e3634b8e6f37"
 dependencies = [
- "itertools",
+ "itertools 0.9.0",
  "thiserror",
  "udgraph",
 ]
@@ -125,6 +158,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.10.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,7 +211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "lazy_static",
  "maybe-uninit",
@@ -156,7 +225,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crossbeam-utils",
  "maybe-uninit",
 ]
@@ -168,8 +237,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -192,6 +283,7 @@ dependencies = [
  "chrono",
  "clap",
  "conllu",
+ "criterion",
  "finalfusion",
  "fnv",
  "git2",
@@ -221,7 +313,7 @@ checksum = "7c103bf188c0eada5a0b9756460ba6405bdba5cc420917a2fdffc873fe1e985e"
 dependencies = [
  "byteorder",
  "fnv",
- "itertools",
+ "itertools 0.9.0",
  "memmap",
  "ndarray",
  "ordered-float 2.1.1",
@@ -251,7 +343,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi",
 ]
@@ -270,6 +362,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "half"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -332,12 +430,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
 name = "jobserver"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -398,7 +520,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -427,6 +549,12 @@ name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "memchr"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memmap"
@@ -519,6 +647,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +712,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
+name = "plotters"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,9 +747,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -727,16 +889,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -748,6 +958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +976,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -772,9 +1003,9 @@ checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -840,6 +1071,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,7 +1110,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74b934fb927eb357a296e8077dc38595df76d26ec055a44e7eb2dc8ca653f86"
 dependencies = [
- "itertools",
+ "itertools 0.9.0",
  "petgraph",
  "thiserror",
  "udgraph",
@@ -929,10 +1170,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
+
+[[package]]
+name = "web-sys"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,5 +35,10 @@ zipf = "6"
 git2 = "0.13"
 
 [dev-dependencies]
+criterion = "0.3"
 lazy_static = "1"
 maplit = "1"
+
+[[bench]]
+name = "dot_product"
+harness = false

--- a/benches/dot_product.rs
+++ b/benches/dot_product.rs
@@ -1,0 +1,64 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use finalfrontier::vec_simd;
+use ndarray::Array1;
+use ndarray_rand::rand_distr::Normal;
+use ndarray_rand::RandomExt;
+
+const ARRAY_SIZE: usize = 512;
+
+fn random_array(n: usize) -> Array1<f32> {
+    Array1::random((n,), Normal::new(0.0, 0.5).unwrap())
+}
+
+fn dot_avx(c: &mut Criterion) {
+    let u = random_array(ARRAY_SIZE);
+    let v = random_array(ARRAY_SIZE);
+    c.bench_function("dot_avx", move |b| {
+        b.iter(|| black_box(unsafe { vec_simd::avx::dot(u.view(), v.view()) }))
+    });
+}
+
+fn dot_fma(c: &mut Criterion) {
+    let u = random_array(ARRAY_SIZE);
+    let v = random_array(ARRAY_SIZE);
+    c.bench_function("dot_fma", move |b| {
+        b.iter(|| black_box(unsafe { vec_simd::avx_fma::dot(u.view(), v.view()) }))
+    });
+}
+
+fn dot_ndarray(c: &mut Criterion) {
+    let u = random_array(ARRAY_SIZE);
+    let v = random_array(ARRAY_SIZE);
+    c.bench_function("dot_ndarray", move |b| b.iter(|| black_box(u.dot(&v))));
+}
+
+fn dot_sse(c: &mut Criterion) {
+    let u = random_array(ARRAY_SIZE);
+    let v = random_array(ARRAY_SIZE);
+    c.bench_function("dot_sse", move |b| {
+        b.iter(|| black_box(unsafe { vec_simd::sse::dot(u.view(), v.view()) }))
+    });
+}
+
+fn dot_unvectorized(c: &mut Criterion) {
+    let u = random_array(ARRAY_SIZE);
+    let v = random_array(ARRAY_SIZE);
+    c.bench_function("dot_unvectorized", move |b| {
+        b.iter(|| {
+            black_box(vec_simd::dot_unvectorized(
+                u.as_slice().unwrap(),
+                v.as_slice().unwrap(),
+            ))
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    dot_avx,
+    dot_fma,
+    dot_ndarray,
+    dot_sse,
+    dot_unvectorized
+);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) mod loss;
 pub(crate) mod sampling;
 
 mod sgd;
-pub use crate::sgd::SGD;
+pub use crate::sgd::Sgd;
 
 mod train_model;
 pub use crate::train_model::{TrainModel, Trainer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ pub use crate::skipgram_trainer::SkipgramTrainer;
 
 pub(crate) mod util;
 
-pub(crate) mod vec_simd;
+#[doc(hidden)]
+pub mod vec_simd;
 
 mod vocab;
 pub use crate::vocab::{

--- a/src/sgd.rs
+++ b/src/sgd.rs
@@ -10,15 +10,15 @@ use crate::vec_simd::scaled_add;
 ///
 /// This data type applies stochastic gradient descent on sentences.
 #[derive(Clone)]
-pub struct SGD<T> {
+pub struct Sgd<T> {
     loss: Hogwild<f32>,
     model: TrainModel<T>,
     n_examples: Hogwild<usize>,
     n_tokens_processed: Hogwild<usize>,
-    sgd_impl: NegativeSamplingSGD,
+    sgd_impl: NegativeSamplingSgd,
 }
 
-impl<T> SGD<T>
+impl<T> Sgd<T>
 where
     T: Trainer,
 {
@@ -28,9 +28,9 @@ where
 
     /// Construct a new SGD instance,
     pub fn new(model: TrainModel<T>) -> Self {
-        let sgd_impl = NegativeSamplingSGD::new(model.config().negative_samples as usize);
+        let sgd_impl = NegativeSamplingSgd::new(model.config().negative_samples as usize);
 
-        SGD {
+        Sgd {
             loss: Hogwild::default(),
             model,
             n_examples: Hogwild::default(),
@@ -106,14 +106,14 @@ where
 /// for all words that do not co-occur in every step. Instead, such
 /// negatives are sampled, weighted by word frequency.
 #[derive(Clone)]
-pub struct NegativeSamplingSGD {
+pub struct NegativeSamplingSgd {
     negative_samples: usize,
 }
 
-impl NegativeSamplingSGD {
+impl NegativeSamplingSgd {
     /// Create a new loss function.
     pub fn new(negative_samples: usize) -> Self {
-        NegativeSamplingSGD { negative_samples }
+        NegativeSamplingSgd { negative_samples }
     }
 
     /// Perform a step of gradient descent.

--- a/src/subcommands/deps.rs
+++ b/src/subcommands/deps.rs
@@ -11,8 +11,8 @@ use conllu::io::{ReadSentence, Reader, Sentences};
 use finalfrontier::io::{thread_data_conllu, FileProgress, TrainInfo};
 use finalfrontier::{
     BucketIndexerType, CommonConfig, Cutoff, DepembedsConfig, DepembedsTrainer, Dependency,
-    DependencyIterator, SimpleVocab, SimpleVocabConfig, SubwordVocab, Vocab, VocabBuilder,
-    WriteModelBinary, SGD,
+    DependencyIterator, Sgd, SimpleVocab, SimpleVocabConfig, SubwordVocab, Vocab, VocabBuilder,
+    WriteModelBinary,
 };
 use finalfusion::compat::fasttext::FastTextIndexer;
 use finalfusion::prelude::VocabWrap;
@@ -267,7 +267,7 @@ where
         app.depembeds_config(),
         XorShiftRng::from_entropy(),
     );
-    let sgd = SGD::new(trainer.into());
+    let sgd = Sgd::new(trainer.into());
 
     let projectivize = app.depembeds_config().projectivize;
     let mut children = Vec::with_capacity(n_threads);
@@ -310,7 +310,7 @@ where
 
 fn do_work<P, R, V>(
     corpus_path: P,
-    mut sgd: SGD<DepembedsTrainer<R, V>>,
+    mut sgd: Sgd<DepembedsTrainer<R, V>>,
     thread: usize,
     n_threads: usize,
     epochs: u32,

--- a/src/subcommands/progress.rs
+++ b/src/subcommands/progress.rs
@@ -1,10 +1,10 @@
 use std::thread;
 use std::time::Duration;
 
-use finalfrontier::{CommonConfig, Trainer, Vocab, SGD};
+use finalfrontier::{CommonConfig, Sgd, Trainer, Vocab};
 use indicatif::{ProgressBar, ProgressStyle};
 
-pub fn show_progress<T, V>(config: &CommonConfig, sgd: &SGD<T>, update_interval: Duration)
+pub fn show_progress<T, V>(config: &CommonConfig, sgd: &Sgd<T>, update_interval: Duration)
 where
     T: Trainer<InputVocab = V>,
     V: Vocab,

--- a/src/subcommands/skipgram.rs
+++ b/src/subcommands/skipgram.rs
@@ -10,8 +10,8 @@ use anyhow::{Context, Result};
 use clap::{App, Arg, ArgMatches};
 use finalfrontier::io::{thread_data_text, FileProgress, TrainInfo};
 use finalfrontier::{
-    BucketIndexerType, CommonConfig, ModelType, SentenceIterator, SimpleVocab, SkipGramConfig,
-    SkipgramTrainer, SubwordVocab, Vocab, VocabBuilder, WriteModelBinary, SGD,
+    BucketIndexerType, CommonConfig, ModelType, SentenceIterator, Sgd, SimpleVocab, SkipGramConfig,
+    SkipgramTrainer, SubwordVocab, Vocab, VocabBuilder, WriteModelBinary,
 };
 use finalfusion::compat::fasttext::FastTextIndexer;
 use finalfusion::prelude::VocabWrap;
@@ -179,7 +179,7 @@ where
         common_config,
         app.skipgram_config(),
     );
-    let sgd = SGD::new(trainer.into());
+    let sgd = Sgd::new(trainer.into());
 
     let mut children = Vec::with_capacity(n_threads);
     for thread in 0..n_threads {
@@ -220,7 +220,7 @@ where
 
 fn do_work<P, R, V>(
     corpus_path: P,
-    mut sgd: SGD<SkipgramTrainer<R, V>>,
+    mut sgd: Sgd<SkipgramTrainer<R, V>>,
     thread: usize,
     n_threads: usize,
     epochs: u32,

--- a/src/vec_simd.rs
+++ b/src/vec_simd.rs
@@ -1,3 +1,8 @@
+//! Operators vectorized with SIMD.
+//!
+//! This module is not for public consumption, but is made public
+//! for benchmarking.
+
 use ndarray::{ArrayView1, ArrayViewMut1};
 
 /// Dot product: u · v
@@ -63,7 +68,7 @@ pub fn scaled_add(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod sse {
+pub mod sse {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
 
@@ -75,7 +80,7 @@ mod sse {
     use super::{dot_unvectorized, scale_unvectorized, scaled_add_unvectorized};
 
     #[target_feature(enable = "sse")]
-    #[allow(dead_code)]
+    #[allow(clippy::missing_safety_doc, dead_code)]
     pub unsafe fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
         assert_eq!(u.len(), v.len());
 
@@ -106,7 +111,7 @@ mod sse {
 
     #[target_feature(enable = "sse")]
     #[allow(dead_code)]
-    pub unsafe fn scale(mut u: ArrayViewMut1<f32>, a: f32) {
+    pub(crate) unsafe fn scale(mut u: ArrayViewMut1<f32>, a: f32) {
         let mut u = u
             .as_slice_mut()
             .expect("Cannot apply SIMD instructions on non-contiguous data.");
@@ -125,7 +130,7 @@ mod sse {
 
     #[target_feature(enable = "sse")]
     #[allow(dead_code, clippy::float_cmp)]
-    pub unsafe fn scaled_add(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
+    pub(crate) unsafe fn scaled_add(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
         assert_eq!(u.len(), v.len());
 
         let mut u = u
@@ -162,7 +167,7 @@ mod sse {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod avx {
+pub mod avx {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
 
@@ -174,6 +179,7 @@ mod avx {
     use super::{dot_unvectorized, scale_unvectorized, scaled_add_unvectorized};
 
     #[target_feature(enable = "avx")]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
         assert_eq!(u.len(), v.len());
 
@@ -206,7 +212,7 @@ mod avx {
     }
 
     #[target_feature(enable = "avx")]
-    pub unsafe fn scale(mut u: ArrayViewMut1<f32>, a: f32) {
+    pub(crate) unsafe fn scale(mut u: ArrayViewMut1<f32>, a: f32) {
         let mut u = u
             .as_slice_mut()
             .expect("Cannot apply SIMD instructions on non-contiguous data.");
@@ -225,7 +231,7 @@ mod avx {
 
     #[target_feature(enable = "avx")]
     #[allow(clippy::float_cmp)]
-    pub unsafe fn scaled_add(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
+    pub(crate) unsafe fn scaled_add(mut u: ArrayViewMut1<f32>, v: ArrayView1<f32>, a: f32) {
         assert_eq!(u.len(), v.len());
 
         let mut u = u
@@ -266,7 +272,7 @@ mod avx {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-mod avx_fma {
+pub mod avx_fma {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;
 
@@ -278,6 +284,7 @@ mod avx_fma {
     use super::dot_unvectorized;
 
     #[target_feature(enable = "avx", enable = "fma")]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn dot(u: ArrayView1<f32>, v: ArrayView1<f32>) -> f32 {
         assert_eq!(u.len(), v.len());
 


### PR DESCRIPTION
- Add benchmarks for dot products.
- Rewrite register sums to avoid hadd instructions, giving small
  performance improvements across the board.
- Use two accumulators for FMA to avoid pipeline stalls, leading
  to a 38% improvement.
  
Benchmarks below:

~~~
dot_avx                 time:   [38.051 ns 38.076 ns 38.108 ns]                     
                        change: [-2.9680% -2.8665% -2.7561%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

dot_fma                 time:   [34.151 ns 34.166 ns 34.179 ns]                     
                        change: [-38.371% -38.312% -38.257%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

dot_sse                 time:   [80.847 ns 80.862 ns 80.882 ns]                    
                        change: [-4.5626% -4.5090% -4.4474%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  7 (7.00%) high mild
  6 (6.00%) high severe

dot_unvectorized        time:   [338.73 ns 338.79 ns 338.84 ns]                             
                        change: [+0.7094% +0.7583% +0.8104%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
~~~
